### PR TITLE
feat: add x402 pay-per-call support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,35 @@ It also ships one flagship workflow:
 
 ![Wallet analysis demo](./assets/demo-wallet-analysis.svg)
 
-## 1. Get your Zerion API key
+## 1. Choose your authentication method
 
-Start here: [Get your API key](https://dashboard.zerion.io)
+### Option A: x402 Pay-per-call (Recommended for agents)
 
-Useful current docs:
+**No API key needed.** Pay $0.01 USDC per request on Base. Your agent's wallet handles payment automatically via the [x402 protocol](https://www.x402.org/).
 
-- [Build with AI](https://developers.zerion.io/reference/building-with-ai)
-- [Get Wallet Data With Zerion API](https://developers.zerion.io/reference/getting-started)
+```bash
+zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --x402
+```
 
-As of March 8, 2026, Zerion's public authentication docs describe:
+Or set the environment variable:
+
+```bash
+export ZERION_X402=true
+zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
+```
+
+### Option B: API Key
+
+Get an API key for higher rate limits and production use: [Get your API key](https://dashboard.zerion.io)
 
 - API auth via **HTTP Basic Auth**
 - dev keys beginning with `zk_dev_`
 - current dev-key limits of **120 requests/minute** and **5k requests/day**
+
+Useful docs:
+
+- [Build with AI](https://developers.zerion.io/reference/building-with-ai)
+- [Get Wallet Data With Zerion API](https://developers.zerion.io/reference/getting-started)
 
 ## 2. Choose your integration path
 
@@ -75,6 +90,15 @@ Start here:
    ```
 
 ### CLI quickstart
+
+**With x402 (no API key needed):**
+
+```bash
+npm install -g zerion-cli
+zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --x402
+```
+
+**With API key:**
 
 ```bash
 npm install -g zerion-cli

--- a/cli/zerion-cli.js
+++ b/cli/zerion-cli.js
@@ -2,9 +2,11 @@
 
 import { parseFlags, basicAuthHeader, validateChain, validatePositions, resolvePositionFilter, summarizeAnalyze, CHAIN_IDS, POSITION_FILTERS } from "./lib.mjs";
 
-const API_BASE = (process.env.ZERION_API_BASE || "https://api.zerion.io/v1").replace(/\/+$/, "");
+const API_BASE_DEFAULT = "https://api.zerion.io/v1";
+const API_BASE_X402 = "https://api.zerion.io/v1/x402";
 const DEFAULT_TX_LIMIT = 10;
 const API_KEY = process.env.ZERION_API_KEY || "";
+const USE_X402 = process.env.ZERION_X402 === "true";
 
 function print(value) {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
@@ -18,20 +20,25 @@ function usage() {
   print({
     name: "zerion-cli",
     usage: [
-      "zerion-cli wallet analyze <address> [--positions all|simple|defi]",
-      "zerion-cli wallet portfolio <address>",
-      "zerion-cli wallet positions <address> [--chain ethereum] [--positions all|simple|defi]",
-      "zerion-cli wallet transactions <address> [--limit 10] [--chain ethereum]",
-      "zerion-cli wallet pnl <address>",
-      "zerion-cli chains list"
+      "zerion-cli wallet analyze <address> [--positions all|simple|defi] [--x402]",
+      "zerion-cli wallet portfolio <address> [--x402]",
+      "zerion-cli wallet positions <address> [--chain ethereum] [--positions all|simple|defi] [--x402]",
+      "zerion-cli wallet transactions <address> [--limit 10] [--chain ethereum] [--x402]",
+      "zerion-cli wallet pnl <address> [--x402]",
+      "zerion-cli chains list [--x402]"
     ],
-    env: ["ZERION_API_KEY", "ZERION_API_BASE (optional)"]
+    env: ["ZERION_API_KEY", "ZERION_API_BASE (optional)", "ZERION_X402=true (use x402 pay-per-call)"],
+    x402: {
+      description: "Pay $0.01 USDC per request on Base. No API key required.",
+      docs: "https://developers.zerion.io/reference/x402"
+    }
   });
 }
 
-function ensureKey() {
+function ensureKey(useX402) {
+  if (useX402) return; // x402 doesn't require an API key
   if (!API_KEY) {
-    printError("missing_api_key", "ZERION_API_KEY is required.");
+    printError("missing_api_key", "ZERION_API_KEY is required. Alternatively, use --x402 for pay-per-call.");
     process.exit(1);
   }
 }
@@ -52,19 +59,26 @@ function validatePositionsOrExit(positions) {
   }
 }
 
-async function fetchAPI(pathname, params = {}) {
-  const url = new URL(`${API_BASE}${pathname}`);
+async function fetchAPI(pathname, params = {}, useX402 = false) {
+  const apiBase = useX402
+    ? (process.env.ZERION_API_BASE_X402 || API_BASE_X402)
+    : (process.env.ZERION_API_BASE || API_BASE_DEFAULT);
+
+  const url = new URL(`${apiBase}${pathname}`);
   for (const [key, value] of Object.entries(params)) {
     if (value === undefined || value === null || value === "") continue;
     url.searchParams.set(key, String(value));
   }
 
-  const response = await fetch(url, {
-    headers: {
-      Accept: "application/json",
-      Authorization: basicAuthHeader(API_KEY)
-    }
-  });
+  const headers = { Accept: "application/json" };
+
+  // x402 uses the HTTP 402 protocol for payment - no auth header needed
+  // The agent's wallet handles the payment automatically
+  if (!useX402) {
+    headers.Authorization = basicAuthHeader(API_KEY);
+  }
+
+  const response = await fetch(url, { headers });
 
   const text = await response.text();
   let payload;
@@ -84,10 +98,10 @@ async function fetchAPI(pathname, params = {}) {
   return payload;
 }
 
-async function request(pathname, params = {}) {
-  ensureKey();
+async function request(pathname, params = {}, useX402 = false) {
+  ensureKey(useX402);
   try {
-    return await fetchAPI(pathname, params);
+    return await fetchAPI(pathname, params, useX402);
   } catch (err) {
     printError("api_error", err.message, {
       status: err.status,
@@ -97,30 +111,30 @@ async function request(pathname, params = {}) {
   }
 }
 
-async function getPortfolio(address) {
-  return request(`/wallets/${encodeURIComponent(address)}/portfolio`);
+async function getPortfolio(address, useX402 = false) {
+  return request(`/wallets/${encodeURIComponent(address)}/portfolio`, {}, useX402);
 }
 
-async function getPositions(address, chain, positionFilter) {
+async function getPositions(address, chain, positionFilter, useX402 = false) {
   const params = { "filter[positions]": resolvePositionFilter(positionFilter) };
   if (chain) params["filter[chain_ids]"] = chain;
-  return request(`/wallets/${encodeURIComponent(address)}/positions/`, params);
+  return request(`/wallets/${encodeURIComponent(address)}/positions/`, params, useX402);
 }
 
-async function getTransactions(address, chain, limit) {
+async function getTransactions(address, chain, limit, useX402 = false) {
   const params = {
     "page[size]": limit || DEFAULT_TX_LIMIT
   };
   if (chain) params["filter[chain_ids]"] = chain;
-  return request(`/wallets/${encodeURIComponent(address)}/transactions/`, params);
+  return request(`/wallets/${encodeURIComponent(address)}/transactions/`, params, useX402);
 }
 
-async function getPnl(address) {
-  return request(`/wallets/${encodeURIComponent(address)}/pnl`);
+async function getPnl(address, useX402 = false) {
+  return request(`/wallets/${encodeURIComponent(address)}/pnl`, {}, useX402);
 }
 
-async function listChains() {
-  return request("/chains/");
+async function listChains(useX402 = false) {
+  return request("/chains/", {}, useX402);
 }
 
 async function main() {
@@ -133,8 +147,11 @@ async function main() {
   const { rest, flags } = parseFlags(argv);
   const [scope, action, target] = rest;
 
+  // x402 mode: pay-per-call, no API key needed
+  const useX402 = flags.x402 === true || USE_X402;
+
   if (scope === "chains" && action === "list") {
-    print(await listChains());
+    print(await listChains(useX402));
     return;
   }
 
@@ -153,29 +170,29 @@ async function main() {
 
   switch (action) {
     case "portfolio":
-      print(await getPortfolio(target));
+      print(await getPortfolio(target, useX402));
       return;
     case "positions":
-      print(await getPositions(target, flags.chain, flags.positions));
+      print(await getPositions(target, flags.chain, flags.positions, useX402));
       return;
     case "transactions":
-      print(await getTransactions(target, flags.chain, flags.limit));
+      print(await getTransactions(target, flags.chain, flags.limit, useX402));
       return;
     case "pnl":
-      print(await getPnl(target));
+      print(await getPnl(target, useX402));
       return;
     case "analyze": {
-      ensureKey();
+      ensureKey(useX402);
       const addr = encodeURIComponent(target);
       const txParams = { "page[size]": flags.limit || DEFAULT_TX_LIMIT };
       const posParams = { "filter[positions]": resolvePositionFilter(flags.positions) };
       if (flags.chain) posParams["filter[chain_ids]"] = flags.chain;
       if (flags.chain) txParams["filter[chain_ids]"] = flags.chain;
       const results = await Promise.allSettled([
-        fetchAPI(`/wallets/${addr}/portfolio`),
-        fetchAPI(`/wallets/${addr}/positions/`, posParams),
-        fetchAPI(`/wallets/${addr}/transactions/`, txParams),
-        fetchAPI(`/wallets/${addr}/pnl`)
+        fetchAPI(`/wallets/${addr}/portfolio`, {}, useX402),
+        fetchAPI(`/wallets/${addr}/positions/`, posParams, useX402),
+        fetchAPI(`/wallets/${addr}/transactions/`, txParams, useX402),
+        fetchAPI(`/wallets/${addr}/pnl`, {}, useX402)
       ]);
       const labels = ["portfolio", "positions", "transactions", "pnl"];
       const values = results.map((r) => r.status === "fulfilled" ? r.value : null);
@@ -184,6 +201,7 @@ async function main() {
         .filter(Boolean);
       const summary = summarizeAnalyze(target, ...values);
       if (failures.length) summary.failures = failures;
+      if (useX402) summary.auth = "x402";
       print(summary);
       return;
     }

--- a/docs/x402-endpoints.md
+++ b/docs/x402-endpoints.md
@@ -1,0 +1,82 @@
+# x402 Endpoints
+
+Pay-per-call API endpoints using the [x402 protocol](https://www.x402.org/). No API key required - your agent's wallet handles payment automatically ($0.01 USDC per request on Base).
+
+## Base URL
+
+```
+https://api.zerion.io/v1/x402
+```
+
+## Available Endpoints
+
+### Wallet Data
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /wallets/:address/portfolio` | Portfolio overview with total value |
+| `GET /wallets/:address/positions/` | Token balances and DeFi positions |
+| `GET /wallets/:address/transactions/` | Interpreted transaction history |
+| `GET /wallets/:address/pnl` | Profit & Loss (realized + unrealized) |
+| `GET /wallets/:address/charts/:period` | Portfolio value over time |
+
+### NFTs
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /wallets/:address/nft-positions/` | NFTs held by wallet |
+| `GET /wallets/:address/nft-collections/` | NFT holdings by collection |
+| `GET /wallets/:address/nft-portfolio` | NFT portfolio summary |
+| `GET /nfts/` | Search/list NFTs |
+| `GET /nfts/:id` | NFT details |
+
+### Tokens (Fungibles)
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /fungibles/` | Search/list tokens |
+| `GET /fungibles/:id` | Token details |
+| `GET /fungibles/:id/charts/:period` | Token price chart |
+| `GET /fungibles/by-implementation` | Lookup by contract address |
+| `GET /fungibles/by-implementation/charts/:period` | Chart by contract |
+
+### Chains & DApps
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /chains/` | List supported chains |
+| `GET /chains/:id` | Chain details |
+| `GET /dapps/` | List DeFi protocols |
+| `GET /dapps/:id` | DApp details |
+
+## Usage
+
+### CLI
+
+```bash
+zerion-cli wallet portfolio 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --x402
+```
+
+### curl
+
+```bash
+curl https://api.zerion.io/v1/x402/wallets/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045/portfolio
+```
+
+### Environment Variable
+
+```bash
+export ZERION_X402=true
+zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
+```
+
+## Pricing
+
+- **$0.01 USDC per request** on Base
+- Payment handled automatically via HTTP 402 protocol
+- Agent wallet must have USDC balance on Base
+
+## Learn More
+
+- [x402 Protocol](https://www.x402.org/)
+- [Zerion API Docs](https://developers.zerion.io)

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -20,6 +20,20 @@ Use the CLI path when your environment expects shell commands returning JSON.
 
 ## Authentication
 
+Two options:
+
+### Option 1: x402 Pay-per-call (Recommended for agents)
+
+No API key needed. Pay $0.01 USDC per request on Base via the [x402 protocol](https://www.x402.org/).
+
+```bash
+export ZERION_X402=true
+```
+
+Your agent's wallet handles payment automatically.
+
+### Option 2: API Key
+
 1. Get a Zerion API key:
    https://dashboard.zerion.io
 2. Export it:

--- a/skills/wallet-analysis/SKILL.md
+++ b/skills/wallet-analysis/SKILL.md
@@ -36,6 +36,10 @@ If the environment supports MCP, prefer the hosted Zerion MCP and ask directly f
 If the environment expects commands, run:
 
 ```bash
+# With x402 (no API key needed, pay $0.01 USDC per request)
+zerion-cli wallet analyze <wallet> --x402
+
+# With API key
 zerion-cli wallet analyze <wallet>
 zerion-cli wallet analyze <wallet> --positions defi
 ```
@@ -43,12 +47,19 @@ zerion-cli wallet analyze <wallet> --positions defi
 Or fetch the pieces explicitly:
 
 ```bash
-zerion-cli wallet portfolio <wallet>
-zerion-cli wallet positions <wallet>
-zerion-cli wallet positions <wallet> --positions defi
-zerion-cli wallet transactions <wallet> --limit 10
-zerion-cli wallet pnl <wallet>
+zerion-cli wallet portfolio <wallet> [--x402]
+zerion-cli wallet positions <wallet> [--x402]
+zerion-cli wallet positions <wallet> --positions defi [--x402]
+zerion-cli wallet transactions <wallet> --limit 10 [--x402]
+zerion-cli wallet pnl <wallet> [--x402]
 ```
+
+## Authentication
+
+Two options:
+
+1. **x402 pay-per-call** - No signup, pay $0.01 USDC per request on Base. Use `--x402` flag or `ZERION_X402=true`.
+2. **API key** - Get from [dashboard.zerion.io](https://dashboard.zerion.io). Higher rate limits for production.
 
 ## Output
 


### PR DESCRIPTION
## Summary

Add x402 protocol support as an alternative to API key authentication. x402 enables pay-per-call ($0.01 USDC per request on Base) without requiring signup or API keys.

### Changes
- **CLI**: Add `--x402` flag and `ZERION_X402` env var support
- **fetchAPI**: Use `/v1/x402/` base URL when x402 mode enabled
- **Auth**: Skip API key requirement when using x402
- **Docs**: Update README, MCP, and skill docs with x402 option
- **New**: Add `docs/x402-endpoints.md` listing all available endpoints

### Usage

```bash
# With --x402 flag
zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --x402

# With environment variable
ZERION_X402=true zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
```

### x402 Endpoints Available

All wallet endpoints are available via x402:
- `/wallets/:address/portfolio`
- `/wallets/:address/positions/`
- `/wallets/:address/transactions/`
- `/wallets/:address/pnl`
- `/wallets/:address/nft-positions/`
- `/wallets/:address/nft-collections/`
- `/chains/`
- `/fungibles/`
- `/dapps/`

See `docs/x402-endpoints.md` for the full list.

## Test plan
- [ ] Test CLI with `--x402` flag
- [ ] Test CLI with `ZERION_X402=true` env var
- [ ] Verify API calls go to `/v1/x402/` base URL
- [ ] Verify no API key error when using x402

🤖 Generated with [Claude Code](https://claude.com/claude-code)