### PR TITLE
feat: implement x402 payment protocol handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,24 @@ It also ships one flagship workflow:
 
 ## 1. Choose your authentication method
 
-### Option A: x402 Pay-per-call (Recommended for agents)
+### Option A: API Key
+
+Get an API key and export it: [Get your API key](https://dashboard.zerion.io)
+
+```bash
+export ZERION_API_KEY="zk_dev_..."
+```
+
+- API auth via **HTTP Basic Auth**
+- dev keys beginning with `zk_dev_`
+- current dev-key limits of **120 requests/minute** and **5k requests/day**
+
+Useful docs:
+
+- [Build with AI](https://developers.zerion.io/reference/building-with-ai)
+- [Get Wallet Data With Zerion API](https://developers.zerion.io/reference/getting-started)
+
+### Option B: x402 Pay-per-call
 
 **No API key needed.** Pay $0.01 USDC per request on Base via the [x402 protocol](https://www.x402.org/). The CLI handles the payment handshake automatically using your wallet's private key.
 
@@ -39,19 +56,6 @@ Or enable x402 globally:
 export ZERION_X402=true
 zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
 ```
-
-### Option B: API Key
-
-Get an API key for higher rate limits and production use: [Get your API key](https://dashboard.zerion.io)
-
-- API auth via **HTTP Basic Auth**
-- dev keys beginning with `zk_dev_`
-- current dev-key limits of **120 requests/minute** and **5k requests/day**
-
-Useful docs:
-
-- [Build with AI](https://developers.zerion.io/reference/building-with-ai)
-- [Get Wallet Data With Zerion API](https://developers.zerion.io/reference/getting-started)
 
 ## 2. Choose your integration path
 
@@ -99,20 +103,20 @@ Start here:
 
 ### CLI quickstart
 
-**With x402 (no API key needed):**
-
-```bash
-npm install -g zerion-cli
-export WALLET_PRIVATE_KEY="0x..."
-zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --x402
-```
-
 **With API key:**
 
 ```bash
 npm install -g zerion-cli
 export ZERION_API_KEY="zk_dev_..."
 zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
+```
+
+**With x402 (no API key needed):**
+
+```bash
+npm install -g zerion-cli
+export WALLET_PRIVATE_KEY="0x..."
+zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --x402
 ```
 
 Example output:

--- a/README.md
+++ b/README.md
@@ -19,13 +19,21 @@ It also ships one flagship workflow:
 
 ### Option A: x402 Pay-per-call (Recommended for agents)
 
-**No API key needed.** Pay $0.01 USDC per request on Base. Your agent's wallet handles payment automatically via the [x402 protocol](https://www.x402.org/).
+**No API key needed.** Pay $0.01 USDC per request on Base via the [x402 protocol](https://www.x402.org/). The CLI handles the payment handshake automatically using your wallet's private key.
+
+Setup:
+
+```bash
+export WALLET_PRIVATE_KEY="0x..."   # EVM wallet with USDC on Base
+```
+
+Then use the `--x402` flag:
 
 ```bash
 zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --x402
 ```
 
-Or set the environment variable:
+Or enable x402 globally:
 
 ```bash
 export ZERION_X402=true
@@ -95,6 +103,7 @@ Start here:
 
 ```bash
 npm install -g zerion-cli
+export WALLET_PRIVATE_KEY="0x..."
 zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --x402
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,20 +15,35 @@ It also ships one flagship workflow:
 
 ![Wallet analysis demo](./assets/demo-wallet-analysis.svg)
 
-## 1. Get your Zerion API key
+## 1. Choose your authentication method
 
-Start here: [Get your API key](https://dashboard.zerion.io)
+### Option A: x402 Pay-per-call (Recommended for agents)
 
-Useful current docs:
+**No API key needed.** Pay $0.01 USDC per request on Base. Your agent's wallet handles payment automatically via the [x402 protocol](https://www.x402.org/).
 
-- [Build with AI](https://developers.zerion.io/reference/building-with-ai)
-- [Get Wallet Data With Zerion API](https://developers.zerion.io/reference/getting-started)
+```bash
+zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --x402
+```
 
-As of March 8, 2026, Zerion's public authentication docs describe:
+Or set the environment variable:
+
+```bash
+export ZERION_X402=true
+zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
+```
+
+### Option B: API Key
+
+Get an API key for higher rate limits and production use: [Get your API key](https://dashboard.zerion.io)
 
 - API auth via **HTTP Basic Auth**
 - dev keys beginning with `zk_dev_`
 - current dev-key limits of **120 requests/minute** and **5k requests/day**
+
+Useful docs:
+
+- [Build with AI](https://developers.zerion.io/reference/building-with-ai)
+- [Get Wallet Data With Zerion API](https://developers.zerion.io/reference/getting-started)
 
 ## 2. Choose your integration path
 
@@ -75,6 +90,15 @@ Start here:
    ```
 
 ### CLI quickstart
+
+**With x402 (no API key needed):**
+
+```bash
+npm install -g zerion-cli
+zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --x402
+```
+
+**With API key:**
 
 ```bash
 npm install -g zerion-cli

--- a/cli/zerion-cli.js
+++ b/cli/zerion-cli.js
@@ -7,6 +7,23 @@ const API_BASE_X402 = "https://api.zerion.io/v1/x402";
 const DEFAULT_TX_LIMIT = 10;
 const API_KEY = process.env.ZERION_API_KEY || "";
 const USE_X402 = process.env.ZERION_X402 === "true";
+const WALLET_PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY || "";
+
+let _x402Fetch = null;
+async function getX402Fetch() {
+  if (_x402Fetch) return _x402Fetch;
+  if (!WALLET_PRIVATE_KEY) {
+    throw new Error("WALLET_PRIVATE_KEY is required for x402 mode. Set it as an environment variable.");
+  }
+  const { wrapFetchWithPayment, x402Client } = await import("@x402/fetch");
+  const { registerExactEvmScheme } = await import("@x402/evm/exact/client");
+  const { privateKeyToAccount } = await import("viem/accounts");
+  const signer = privateKeyToAccount(WALLET_PRIVATE_KEY);
+  const client = new x402Client();
+  registerExactEvmScheme(client, { signer });
+  _x402Fetch = wrapFetchWithPayment(fetch, client);
+  return _x402Fetch;
+}
 
 function print(value) {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
@@ -27,7 +44,7 @@ function usage() {
       "zerion-cli wallet pnl <address> [--x402]",
       "zerion-cli chains list [--x402]"
     ],
-    env: ["ZERION_API_KEY", "ZERION_API_BASE (optional)", "ZERION_X402=true (use x402 pay-per-call)"],
+    env: ["ZERION_API_KEY", "ZERION_API_BASE (optional)", "ZERION_X402=true (use x402 pay-per-call)", "WALLET_PRIVATE_KEY (required for x402)"],
     x402: {
       description: "Pay $0.01 USDC per request on Base. No API key required.",
       docs: "https://developers.zerion.io/reference/x402"
@@ -72,13 +89,12 @@ async function fetchAPI(pathname, params = {}, useX402 = false) {
 
   const headers = { Accept: "application/json" };
 
-  // x402 uses the HTTP 402 protocol for payment - no auth header needed
-  // The agent's wallet handles the payment automatically
   if (!useX402) {
     headers.Authorization = basicAuthHeader(API_KEY);
   }
 
-  const response = await fetch(url, { headers });
+  const fetchFn = useX402 ? await getX402Fetch() : fetch;
+  const response = await fetchFn(url, { headers });
 
   const text = await response.text();
   let payload;

--- a/cli/zerion-cli.js
+++ b/cli/zerion-cli.js
@@ -1,13 +1,17 @@
 #!/usr/bin/env node
 
-import { parseFlags, basicAuthHeader, validateChain, validatePositions, resolvePositionFilter, summarizeAnalyze, CHAIN_IDS, POSITION_FILTERS } from "./lib.mjs";
+import { parseFlags, basicAuthHeader, validateChain, validatePositions, resolvePositionFilter, summarizeAnalyze } from "./lib.mjs";
 
 const API_BASE_DEFAULT = "https://api.zerion.io/v1";
-const API_BASE_X402 = "https://api.zerion.io/v1/x402";
 const DEFAULT_TX_LIMIT = 10;
 const API_KEY = process.env.ZERION_API_KEY || "";
 const USE_X402 = process.env.ZERION_X402 === "true";
 const WALLET_PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY || "";
+
+let debug = false;
+function debugLog(...args) {
+  if (debug) process.stderr.write(`[debug] ${args.join(" ")}\n`);
+}
 
 let _x402Fetch = null;
 async function getX402Fetch() {
@@ -77,9 +81,7 @@ function validatePositionsOrExit(positions) {
 }
 
 async function fetchAPI(pathname, params = {}, useX402 = false) {
-  const apiBase = useX402
-    ? (process.env.ZERION_API_BASE_X402 || API_BASE_X402)
-    : (process.env.ZERION_API_BASE || API_BASE_DEFAULT);
+  const apiBase = process.env.ZERION_API_BASE || API_BASE_DEFAULT;
 
   const url = new URL(`${apiBase}${pathname}`);
   for (const [key, value] of Object.entries(params)) {
@@ -93,8 +95,12 @@ async function fetchAPI(pathname, params = {}, useX402 = false) {
     headers.Authorization = basicAuthHeader(API_KEY);
   }
 
+  debugLog(`${useX402 ? "x402" : "api"} GET ${url}`);
+
   const fetchFn = useX402 ? await getX402Fetch() : fetch;
   const response = await fetchFn(url, { headers });
+
+  debugLog(`response ${response.status} ${url}`);
 
   const text = await response.text();
   let payload;
@@ -105,6 +111,7 @@ async function fetchAPI(pathname, params = {}, useX402 = false) {
   }
 
   if (!response.ok) {
+    debugLog(`error body: ${text.slice(0, 500)}`);
     const err = new Error(`Zerion API request failed with status ${response.status}.`);
     err.status = response.status;
     err.response = payload;
@@ -165,6 +172,7 @@ async function main() {
 
   // x402 mode: pay-per-call, no API key needed
   const useX402 = flags.x402 === true || USE_X402;
+  debug = flags.debug === true;
 
   if (scope === "chains" && action === "list") {
     print(await listChains(useX402));
@@ -213,7 +221,13 @@ async function main() {
       const labels = ["portfolio", "positions", "transactions", "pnl"];
       const values = results.map((r) => r.status === "fulfilled" ? r.value : null);
       const failures = results
-        .map((r, i) => r.status === "rejected" ? labels[i] : null)
+        .map((r, i) => {
+          if (r.status === "rejected") {
+            debugLog(`${labels[i]} failed: ${r.reason?.message}\n${r.reason?.stack}`);
+            return labels[i];
+          }
+          return null;
+        })
         .filter(Boolean);
       const summary = summarizeAnalyze(target, ...values);
       if (failures.length) summary.failures = failures;

--- a/cli/zerion-cli.js
+++ b/cli/zerion-cli.js
@@ -2,9 +2,11 @@
 
 import { parseFlags, basicAuthHeader, validateChain, validatePositions, resolvePositionFilter, summarizeAnalyze, CHAIN_IDS, POSITION_FILTERS } from "./lib.mjs";
 
-const API_BASE = (process.env.ZERION_API_BASE || "https://api.zerion.io/v1").replace(/\/+$/, "");
+const API_BASE_DEFAULT = "https://api.zerion.io/v1";
+const API_BASE_X402 = "https://api.zerion.io/v1/x402";
 const DEFAULT_TX_LIMIT = 10;
 const API_KEY = process.env.ZERION_API_KEY || "";
+const USE_X402 = process.env.ZERION_X402 === "true";
 
 function print(value) {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
@@ -18,20 +20,25 @@ function usage() {
   print({
     name: "zerion-cli",
     usage: [
-      "zerion-cli wallet analyze <address> [--positions all|simple|defi]",
-      "zerion-cli wallet portfolio <address>",
-      "zerion-cli wallet positions <address> [--chain ethereum] [--positions all|simple|defi]",
-      "zerion-cli wallet transactions <address> [--limit 10] [--chain ethereum]",
-      "zerion-cli wallet pnl <address>",
-      "zerion-cli chains list"
+      "zerion-cli wallet analyze <address> [--positions all|simple|defi] [--x402]",
+      "zerion-cli wallet portfolio <address> [--x402]",
+      "zerion-cli wallet positions <address> [--chain ethereum] [--positions all|simple|defi] [--x402]",
+      "zerion-cli wallet transactions <address> [--limit 10] [--chain ethereum] [--x402]",
+      "zerion-cli wallet pnl <address> [--x402]",
+      "zerion-cli chains list [--x402]"
     ],
-    env: ["ZERION_API_KEY", "ZERION_API_BASE (optional)"]
+    env: ["ZERION_API_KEY", "ZERION_API_BASE (optional)", "ZERION_X402=true (use x402 pay-per-call)"],
+    x402: {
+      description: "Pay $0.01 USDC per request on Base. No API key required.",
+      docs: "https://developers.zerion.io/reference/x402"
+    }
   });
 }
 
-function ensureKey() {
+function ensureKey(useX402) {
+  if (useX402) return; // x402 doesn't require an API key
   if (!API_KEY) {
-    printError("missing_api_key", "ZERION_API_KEY is required.");
+    printError("missing_api_key", "ZERION_API_KEY is required. Alternatively, use --x402 for pay-per-call.");
     process.exit(1);
   }
 }
@@ -52,19 +59,26 @@ function validatePositionsOrExit(positions) {
   }
 }
 
-async function fetchAPI(pathname, params = {}) {
-  const url = new URL(`${API_BASE}${pathname}`);
+async function fetchAPI(pathname, params = {}, useX402 = false) {
+  const apiBase = useX402
+    ? (process.env.ZERION_API_BASE_X402 || API_BASE_X402)
+    : (process.env.ZERION_API_BASE || API_BASE_DEFAULT);
+
+  const url = new URL(`${apiBase}${pathname}`);
   for (const [key, value] of Object.entries(params)) {
     if (value === undefined || value === null || value === "") continue;
     url.searchParams.set(key, String(value));
   }
 
-  const response = await fetch(url, {
-    headers: {
-      Accept: "application/json",
-      Authorization: basicAuthHeader(API_KEY)
-    }
-  });
+  const headers = { Accept: "application/json" };
+
+  // x402 uses the HTTP 402 protocol for payment - no auth header needed
+  // The agent's wallet handles the payment automatically
+  if (!useX402) {
+    headers.Authorization = basicAuthHeader(API_KEY);
+  }
+
+  const response = await fetch(url, { headers });
 
   const text = await response.text();
   let payload;
@@ -84,10 +98,10 @@ async function fetchAPI(pathname, params = {}) {
   return payload;
 }
 
-async function request(pathname, params = {}) {
-  ensureKey();
+async function request(pathname, params = {}, useX402 = false) {
+  ensureKey(useX402);
   try {
-    return await fetchAPI(pathname, params);
+    return await fetchAPI(pathname, params, useX402);
   } catch (err) {
     printError("api_error", err.message, {
       status: err.status,
@@ -97,30 +111,30 @@ async function request(pathname, params = {}) {
   }
 }
 
-async function getPortfolio(address) {
-  return request(`/wallets/${encodeURIComponent(address)}/portfolio`);
+async function getPortfolio(address, useX402 = false) {
+  return request(`/wallets/${encodeURIComponent(address)}/portfolio`, {}, useX402);
 }
 
-async function getPositions(address, chain, positionFilter) {
+async function getPositions(address, chain, positionFilter, useX402 = false) {
   const params = { "filter[positions]": resolvePositionFilter(positionFilter) };
   if (chain) params["filter[chain_ids]"] = chain;
-  return request(`/wallets/${encodeURIComponent(address)}/positions/`, params);
+  return request(`/wallets/${encodeURIComponent(address)}/positions/`, params, useX402);
 }
 
-async function getTransactions(address, chain, limit) {
+async function getTransactions(address, chain, limit, useX402 = false) {
   const params = {
     "page[size]": limit || DEFAULT_TX_LIMIT
   };
   if (chain) params["filter[chain_ids]"] = chain;
-  return request(`/wallets/${encodeURIComponent(address)}/transactions/`, params);
+  return request(`/wallets/${encodeURIComponent(address)}/transactions/`, params, useX402);
 }
 
-async function getPnl(address) {
-  return request(`/wallets/${encodeURIComponent(address)}/pnl`);
+async function getPnl(address, useX402 = false) {
+  return request(`/wallets/${encodeURIComponent(address)}/pnl`, {}, useX402);
 }
 
-async function listChains() {
-  return request("/chains/");
+async function listChains(useX402 = false) {
+  return request("/chains/", {}, useX402);
 }
 
 async function main() {
@@ -133,8 +147,11 @@ async function main() {
   const { rest, flags } = parseFlags(argv);
   const [scope, action, target] = rest;
 
+  // x402 mode: pay-per-call, no API key needed
+  const useX402 = flags.x402 === true || USE_X402;
+
   if (scope === "chains" && action === "list") {
-    print(await listChains());
+    print(await listChains(useX402));
     return;
   }
 
@@ -153,29 +170,29 @@ async function main() {
 
   switch (action) {
     case "portfolio":
-      print(await getPortfolio(target));
+      print(await getPortfolio(target, useX402));
       return;
     case "positions":
-      print(await getPositions(target, flags.chain, flags.positions));
+      print(await getPositions(target, flags.chain, flags.positions, useX402));
       return;
     case "transactions":
-      print(await getTransactions(target, flags.chain, flags.limit));
+      print(await getTransactions(target, flags.chain, flags.limit, useX402));
       return;
     case "pnl":
-      print(await getPnl(target));
+      print(await getPnl(target, useX402));
       return;
     case "analyze": {
-      ensureKey();
+      ensureKey(useX402);
       const addr = encodeURIComponent(target);
       const txParams = { "page[size]": flags.limit || DEFAULT_TX_LIMIT };
       const posParams = { "filter[positions]": resolvePositionFilter(flags.positions) };
       if (flags.chain) posParams["filter[chain_ids]"] = flags.chain;
       if (flags.chain) txParams["filter[chain_ids]"] = flags.chain;
       const results = await Promise.allSettled([
-        fetchAPI(`/wallets/${addr}/portfolio`),
-        fetchAPI(`/wallets/${addr}/positions/`, posParams),
-        fetchAPI(`/wallets/${addr}/transactions/`, txParams),
-        fetchAPI(`/wallets/${addr}/pnl`)
+        fetchAPI(`/wallets/${addr}/portfolio`, {}, useX402),
+        fetchAPI(`/wallets/${addr}/positions/`, posParams, useX402),
+        fetchAPI(`/wallets/${addr}/transactions/`, txParams, useX402),
+        fetchAPI(`/wallets/${addr}/pnl`, {}, useX402)
       ]);
       const labels = ["portfolio", "positions", "transactions", "pnl"];
       const values = results.map((r) => r.status === "fulfilled" ? r.value : null);
@@ -184,6 +201,7 @@ async function main() {
         .filter(Boolean);
       const summary = summarizeAnalyze(target, ...values);
       if (failures.length) summary.failures = failures;
+      if (useX402) summary.auth = "x402";
       print(summary);
       return;
     }

--- a/docs/x402-endpoints.md
+++ b/docs/x402-endpoints.md
@@ -1,6 +1,16 @@
 # x402 Endpoints
 
-Pay-per-call API endpoints using the [x402 protocol](https://www.x402.org/). No API key required - your agent's wallet handles payment automatically ($0.01 USDC per request on Base).
+Pay-per-call API endpoints using the [x402 protocol](https://www.x402.org/). No API key required ($0.01 USDC per request on Base).
+
+## Prerequisites
+
+Set `WALLET_PRIVATE_KEY` to an EVM private key whose address holds USDC on Base:
+
+```bash
+export WALLET_PRIVATE_KEY="0x..."
+```
+
+The CLI uses [`@x402/fetch`](https://www.npmjs.com/package/@x402/fetch) and [`@x402/evm`](https://www.npmjs.com/package/@x402/evm) to handle the 402 payment handshake automatically.
 
 ## Base URL
 

--- a/docs/x402-endpoints.md
+++ b/docs/x402-endpoints.md
@@ -1,0 +1,82 @@
+# x402 Endpoints
+
+Pay-per-call API endpoints using the [x402 protocol](https://www.x402.org/). No API key required - your agent's wallet handles payment automatically ($0.01 USDC per request on Base).
+
+## Base URL
+
+```
+https://api.zerion.io/v1/x402
+```
+
+## Available Endpoints
+
+### Wallet Data
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /wallets/:address/portfolio` | Portfolio overview with total value |
+| `GET /wallets/:address/positions/` | Token balances and DeFi positions |
+| `GET /wallets/:address/transactions/` | Interpreted transaction history |
+| `GET /wallets/:address/pnl` | Profit & Loss (realized + unrealized) |
+| `GET /wallets/:address/charts/:period` | Portfolio value over time |
+
+### NFTs
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /wallets/:address/nft-positions/` | NFTs held by wallet |
+| `GET /wallets/:address/nft-collections/` | NFT holdings by collection |
+| `GET /wallets/:address/nft-portfolio` | NFT portfolio summary |
+| `GET /nfts/` | Search/list NFTs |
+| `GET /nfts/:id` | NFT details |
+
+### Tokens (Fungibles)
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /fungibles/` | Search/list tokens |
+| `GET /fungibles/:id` | Token details |
+| `GET /fungibles/:id/charts/:period` | Token price chart |
+| `GET /fungibles/by-implementation` | Lookup by contract address |
+| `GET /fungibles/by-implementation/charts/:period` | Chart by contract |
+
+### Chains & DApps
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /chains/` | List supported chains |
+| `GET /chains/:id` | Chain details |
+| `GET /dapps/` | List DeFi protocols |
+| `GET /dapps/:id` | DApp details |
+
+## Usage
+
+### CLI
+
+```bash
+zerion-cli wallet portfolio 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --x402
+```
+
+### curl
+
+```bash
+curl https://api.zerion.io/v1/x402/wallets/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045/portfolio
+```
+
+### Environment Variable
+
+```bash
+export ZERION_X402=true
+zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
+```
+
+## Pricing
+
+- **$0.01 USDC per request** on Base
+- Payment handled automatically via HTTP 402 protocol
+- Agent wallet must have USDC balance on Base
+
+## Learn More
+
+- [x402 Protocol](https://www.x402.org/)
+- [Zerion API Docs](https://developers.zerion.io)

--- a/docs/x402-endpoints.md
+++ b/docs/x402-endpoints.md
@@ -15,7 +15,7 @@ The CLI uses [`@x402/fetch`](https://www.npmjs.com/package/@x402/fetch) and [`@x
 ## Base URL
 
 ```
-https://api.zerion.io/v1/x402
+https://api.zerion.io/v1
 ```
 
 ## Available Endpoints
@@ -70,7 +70,7 @@ zerion-cli wallet portfolio 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --x402
 ### curl
 
 ```bash
-curl https://api.zerion.io/v1/x402/wallets/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045/portfolio
+curl https://api.zerion.io/v1/wallets/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045/portfolio
 ```
 
 ### Environment Variable

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -22,18 +22,7 @@ Use the CLI path when your environment expects shell commands returning JSON.
 
 Two options:
 
-### Option 1: x402 Pay-per-call (Recommended for agents)
-
-No API key needed. Pay $0.01 USDC per request on Base via the [x402 protocol](https://www.x402.org/).
-
-```bash
-export WALLET_PRIVATE_KEY="0x..."   # EVM wallet with USDC on Base
-export ZERION_X402=true
-```
-
-The CLI signs the payment automatically using `@x402/fetch` and `@x402/evm`. Your wallet must hold USDC on Base.
-
-### Option 2: API Key
+### Option 1: API Key
 
 1. Get a Zerion API key:
    https://dashboard.zerion.io
@@ -46,6 +35,17 @@ The CLI signs the payment automatically using `@x402/fetch` and `@x402/evm`. You
 3. Reuse it in the MCP client config.
 
 This repo's example configs assume an `Authorization: Bearer ...` header for the hosted MCP and standard Basic Auth for raw REST requests.
+
+### Option 2: x402 Pay-per-call
+
+No API key needed. Pay $0.01 USDC per request on Base via the [x402 protocol](https://www.x402.org/).
+
+```bash
+export WALLET_PRIVATE_KEY="0x..."   # EVM wallet with USDC on Base
+export ZERION_X402=true
+```
+
+The CLI signs the payment automatically using `@x402/fetch` and `@x402/evm`. Your wallet must hold USDC on Base.
 
 ## Supported clients in this repo
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -27,10 +27,11 @@ Two options:
 No API key needed. Pay $0.01 USDC per request on Base via the [x402 protocol](https://www.x402.org/).
 
 ```bash
+export WALLET_PRIVATE_KEY="0x..."   # EVM wallet with USDC on Base
 export ZERION_X402=true
 ```
 
-Your agent's wallet handles payment automatically.
+The CLI signs the payment automatically using `@x402/fetch` and `@x402/evm`. Your wallet must hold USDC on Base.
 
 ### Option 2: API Key
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -20,6 +20,20 @@ Use the CLI path when your environment expects shell commands returning JSON.
 
 ## Authentication
 
+Two options:
+
+### Option 1: x402 Pay-per-call (Recommended for agents)
+
+No API key needed. Pay $0.01 USDC per request on Base via the [x402 protocol](https://www.x402.org/).
+
+```bash
+export ZERION_X402=true
+```
+
+Your agent's wallet handles payment automatically.
+
+### Option 2: API Key
+
 1. Get a Zerion API key:
    https://dashboard.zerion.io
 2. Export it:

--- a/package.json
+++ b/package.json
@@ -2,14 +2,22 @@
   "name": "zerion-cli",
   "version": "0.1.0",
   "description": "Zerion for AI agents and developers: hosted MCP docs, wallet-analysis skill, and a JSON-first CLI.",
+  "author": "Zerion",
   "type": "module",
   "bin": {
     "zerion-cli": "./cli/zerion-cli.js"
   },
+  "files": [
+    "cli/*.js",
+    "cli/*.mjs",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "test": "node --test tests/*.test.mjs",
     "test:unit": "node --test tests/unit.test.mjs tests/tool-catalog.test.mjs tests/examples.test.mjs tests/consistency.test.mjs",
-    "test:integration": "node --test tests/integration.test.mjs"
+    "test:integration": "node --test tests/integration.test.mjs",
+    "prepublishOnly": "npm test"
   },
   "engines": {
     "node": ">=20"
@@ -22,5 +30,13 @@
     "openclaw",
     "cli"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zeriontech/zerion-ai.git"
+  },
+  "bugs": {
+    "url": "https://github.com/zeriontech/zerion-ai/issues"
+  },
+  "homepage": "https://github.com/zeriontech/zerion-ai#readme",
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   "homepage": "https://github.com/zeriontech/zerion-ai#readme",
   "license": "MIT",
   "dependencies": {
-    "@x402/fetch": "^0.1.0",
-    "@x402/evm": "^0.1.0",
+    "@x402/fetch": "^2.6.0",
+    "@x402/evm": "^2.6.0",
     "viem": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,5 +38,10 @@
     "url": "https://github.com/zeriontech/zerion-ai/issues"
   },
   "homepage": "https://github.com/zeriontech/zerion-ai#readme",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "@x402/fetch": "^0.1.0",
+    "@x402/evm": "^0.1.0",
+    "viem": "^2.0.0"
+  }
 }

--- a/skills/wallet-analysis/SKILL.md
+++ b/skills/wallet-analysis/SKILL.md
@@ -58,7 +58,7 @@ zerion-cli wallet pnl <wallet> [--x402]
 
 Two options:
 
-1. **x402 pay-per-call** - No signup, pay $0.01 USDC per request on Base. Use `--x402` flag or `ZERION_X402=true`.
+1. **x402 pay-per-call** - No signup, pay $0.01 USDC per request on Base. Set `WALLET_PRIVATE_KEY` to an EVM private key with USDC on Base, then use the `--x402` flag or `ZERION_X402=true`.
 2. **API key** - Get from [dashboard.zerion.io](https://dashboard.zerion.io). Higher rate limits for production.
 
 ## Output

--- a/skills/wallet-analysis/SKILL.md
+++ b/skills/wallet-analysis/SKILL.md
@@ -36,6 +36,10 @@ If the environment supports MCP, prefer the hosted Zerion MCP and ask directly f
 If the environment expects commands, run:
 
 ```bash
+# With x402 (no API key needed, pay $0.01 USDC per request)
+zerion-cli wallet analyze <wallet> --x402
+
+# With API key
 zerion-cli wallet analyze <wallet>
 zerion-cli wallet analyze <wallet> --positions defi
 ```
@@ -43,12 +47,19 @@ zerion-cli wallet analyze <wallet> --positions defi
 Or fetch the pieces explicitly:
 
 ```bash
-zerion-cli wallet portfolio <wallet>
-zerion-cli wallet positions <wallet>
-zerion-cli wallet positions <wallet> --positions defi
-zerion-cli wallet transactions <wallet> --limit 10
-zerion-cli wallet pnl <wallet>
+zerion-cli wallet portfolio <wallet> [--x402]
+zerion-cli wallet positions <wallet> [--x402]
+zerion-cli wallet positions <wallet> --positions defi [--x402]
+zerion-cli wallet transactions <wallet> --limit 10 [--x402]
+zerion-cli wallet pnl <wallet> [--x402]
 ```
+
+## Authentication
+
+Two options:
+
+1. **x402 pay-per-call** - No signup, pay $0.01 USDC per request on Base. Use `--x402` flag or `ZERION_X402=true`.
+2. **API key** - Get from [dashboard.zerion.io](https://dashboard.zerion.io). Higher rate limits for production.
 
 ## Output
 

--- a/tests/integration.test.mjs
+++ b/tests/integration.test.mjs
@@ -11,7 +11,7 @@ const API_KEY = process.env.ZERION_API_KEY || "";
 const SKIP = !API_KEY;
 const SKIP_MSG = "Skipping: ZERION_API_KEY not set";
 
-const VITALIK = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+const VITALIK = "0x42b9dF65B219B3dD36FF330A4dD8f327A6Ada990";
 
 function run(args) {
   return new Promise((resolve) => {


### PR DESCRIPTION
 ## Summary

  - Adds `@x402/fetch` and `@x402/evm` to handle the x402 payment protocol (402 → sign USDC payment →
  retry with `X-PAYMENT` header)
  - Reads `WALLET_PRIVATE_KEY` from env to create a viem signer for Base USDC payments
  - Replaces plain `fetch()` with x402-wrapped fetch when `--x402` is used, so the handshake actually
  completes

  Builds on top of #1 which added the `--x402` flag, routing, and docs but was missing the payment
  implementation (plain fetch just gets a 402 error back).

  ## Test plan

  - [ ] `WALLET_PRIVATE_KEY=<key> zerion-cli chains list --x402` returns chain data (not a 402 error)
  - [ ] `zerion-cli chains list` (without --x402) still works with `ZERION_API_KEY`
  - [ ] Missing `WALLET_PRIVATE_KEY` with `--x402` gives a clear error message