### PR TITLE
Remove raw API dump from analyze — 14MB → 7KB

### DIFF
--- a/cli/lib.mjs
+++ b/cli/lib.mjs
@@ -96,29 +96,63 @@ export function validateChain(chain) {
 }
 
 export function summarizeAnalyze(address, portfolio, positions, transactions, pnl) {
+  const topPositions = Array.isArray(positions?.data)
+    ? positions.data
+        .sort((a, b) =>
+          (b.attributes?.value ?? 0) - (a.attributes?.value ?? 0))
+        .slice(0, 10)
+        .map((p) => ({
+          name: p.attributes?.fungible_info?.name ?? p.attributes?.name ?? "Unknown",
+          symbol: p.attributes?.fungible_info?.symbol ?? null,
+          value: p.attributes?.value ?? 0,
+          quantity: p.attributes?.quantity?.float ?? null,
+          chain: p.relationships?.chain?.data?.id ?? null
+        }))
+    : [];
+
+  const recentTxs = Array.isArray(transactions?.data)
+    ? transactions.data.slice(0, 5).map((tx) => ({
+        hash: tx.attributes?.hash ?? null,
+        status: tx.attributes?.status ?? null,
+        mined_at: tx.attributes?.mined_at ?? null,
+        operation_type: tx.attributes?.operation_type ?? null,
+        fee: tx.attributes?.fee?.value ?? null,
+        transfers: Array.isArray(tx.attributes?.transfers)
+          ? tx.attributes.transfers.map((t) => ({
+              direction: t.direction,
+              fungible_info: t.fungible_info
+                ? { name: t.fungible_info.name, symbol: t.fungible_info.symbol }
+                : null,
+              quantity: t.quantity?.float ?? null,
+              value: t.value ?? null
+            }))
+          : []
+      }))
+    : [];
+
+  const chainBreakdown = portfolio?.data?.attributes?.positions_distribution_by_chain ?? null;
+
   return {
     wallet: {
       query: address
     },
     portfolio: {
       total: portfolio?.data?.attributes?.total?.positions ?? null,
-      currency: "usd"
+      currency: "usd",
+      change_1d: portfolio?.data?.attributes?.changes ?? null,
+      chains: chainBreakdown
     },
     positions: {
-      count: Array.isArray(positions?.data) ? positions.data.length : 0
+      count: Array.isArray(positions?.data) ? positions.data.length : 0,
+      top: topPositions
     },
     transactions: {
-      sampled: Array.isArray(transactions?.data) ? transactions.data.length : 0
+      sampled: Array.isArray(transactions?.data) ? transactions.data.length : 0,
+      recent: recentTxs
     },
     pnl: {
       available: Boolean(pnl?.data),
       summary: pnl?.data?.attributes ?? null
-    },
-    raw: {
-      portfolio,
-      positions,
-      transactions,
-      pnl
     }
   };
 }

--- a/tests/unit.test.mjs
+++ b/tests/unit.test.mjs
@@ -167,9 +167,12 @@ describe("resolvePositionFilter", () => {
 
 describe("summarizeAnalyze", () => {
   it("returns all fields for full valid data", () => {
-    const portfolio = { data: { attributes: { total: { positions: 50000 } } } };
-    const positions = { data: [{ id: "1" }, { id: "2" }] };
-    const transactions = { data: [{ id: "tx1" }] };
+    const portfolio = { data: { attributes: { total: { positions: 50000 }, changes: { absolute_1d: -100, percent_1d: -0.2 }, positions_distribution_by_chain: { ethereum: 45000, base: 5000 } } } };
+    const positions = { data: [
+      { attributes: { fungible_info: { name: "Ether", symbol: "ETH" }, value: 40000, quantity: { float: 20 } }, relationships: { chain: { data: { id: "ethereum" } } } },
+      { attributes: { fungible_info: { name: "USD Coin", symbol: "USDC" }, value: 10000, quantity: { float: 10000 } }, relationships: { chain: { data: { id: "base" } } } }
+    ] };
+    const transactions = { data: [{ attributes: { hash: "0x123", status: "confirmed", mined_at: "2026-01-01", operation_type: "trade", fee: { value: 0.01 }, transfers: [{ direction: "out", fungible_info: { name: "Ether", symbol: "ETH" }, quantity: { float: 1 }, value: 2000 }] } }] };
     const pnl = { data: { attributes: { realized: 100 } } };
 
     const result = summarizeAnalyze("0xABC", portfolio, positions, transactions, pnl);
@@ -177,11 +180,16 @@ describe("summarizeAnalyze", () => {
     assert.equal(result.wallet.query, "0xABC");
     assert.equal(result.portfolio.total, 50000);
     assert.equal(result.portfolio.currency, "usd");
+    assert.deepEqual(result.portfolio.chains, { ethereum: 45000, base: 5000 });
     assert.equal(result.positions.count, 2);
+    assert.equal(result.positions.top.length, 2);
+    assert.equal(result.positions.top[0].name, "Ether");
     assert.equal(result.transactions.sampled, 1);
+    assert.equal(result.transactions.recent.length, 1);
+    assert.equal(result.transactions.recent[0].hash, "0x123");
     assert.equal(result.pnl.available, true);
     assert.deepEqual(result.pnl.summary, { realized: 100 });
-    assert.ok(result.raw);
+    assert.equal(result.raw, undefined);
   });
 
   it("handles all null/undefined responses gracefully", () => {


### PR DESCRIPTION
## Summary

- `wallet analyze` included full raw API responses for all 4 endpoints (portfolio, positions, transactions, pnl). For wallets like vitalik.eth (~7000 positions), this produced **14MB of JSON** — unusable in any agent context window.
- Replaced the `raw` dump with structured summaries: top 10 positions, 5 recent transactions with parsed transfers, chain breakdown, and 1-day portfolio change.
- Individual subcommands (`wallet portfolio`, `wallet positions`, etc.) still return full API responses when raw data is needed.

## Test plan

- [x] All 123 unit tests pass (14 integration tests skipped without API key)
- [x] Verified live output: vitalik.eth analyze went from 14MB → 6.8KB
- [x] Output includes all actionable data an agent needs (portfolio total, top positions, recent txs, PnL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)