### PR TITLE
Add 3 skills for npx skills add ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,23 @@ export ZERION_X402=true
 zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
 ```
 
-## 2. Choose your integration path
+## 2. Install skills (Claude Code, Cursor, OpenClaw)
+
+```bash
+npx skills add zeriontech/zerion-ai
+```
+
+This installs 3 skills into your agent:
+
+| Skill | Description |
+|-------|-------------|
+| **wallet-analysis** | Analyze wallets: portfolio, positions, transactions, PnL |
+| **chains** | List supported blockchain networks |
+| **zerion-cli** | CLI setup, authentication, and troubleshooting |
+
+The skills reference `zerion-cli` which runs via `npx zerion-cli` (no global install needed).
+
+## 3. Choose your integration path
 
 ### MCP clients
 
@@ -83,7 +99,7 @@ Start here:
 - [OpenClaw example](./examples/openclaw/README.md)
 - [CLI usage](./cli/README.md)
 
-## 3. Run the first wallet analysis
+## 4. Run the first wallet analysis
 
 ### MCP quickstart
 
@@ -152,9 +168,12 @@ This repo uses the same public wallets across examples:
 
 ## What ships in this repo
 
-- [`mcp/`](./mcp/README.md): hosted Zerion MCP setup plus the wallet-analysis tool catalog this repo relies on
-- [`skills/wallet-analysis/`](./skills/wallet-analysis/README.md): the flagship read-only skill
-- [`cli/`](./cli/README.md): `zerion-cli` JSON-first CLI
+- [`skills/`](./skills/): 3 agent skills installable via `npx skills add zeriontech/zerion-ai`
+  - [`wallet-analysis/`](./skills/wallet-analysis/SKILL.md): portfolio, positions, transactions, and PnL analysis
+  - [`chains/`](./skills/chains/SKILL.md): supported blockchain networks reference
+  - [`zerion-cli/`](./skills/zerion-cli/SKILL.md): CLI setup, auth, and troubleshooting
+- [`mcp/`](./mcp/README.md): hosted Zerion MCP setup plus the tool catalog
+- [`cli/`](./cli/README.md): `zerion-cli` JSON-first CLI (published to npm)
 - [`examples/`](./examples/): Cursor, Claude, OpenAI Agents SDK, raw HTTP, and OpenClaw setups
 
 ## Failure modes to expect

--- a/skills/chains/LICENSE.txt
+++ b/skills/chains/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Zerion
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/chains/SKILL.md
+++ b/skills/chains/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: chains
+description: "List blockchain networks supported by Zerion. Use when validating chain names, checking supported networks, or looking up chain metadata before querying wallet data."
+compatibility: "Requires zerion-cli (`npx zerion-cli` or `npm install -g zerion-cli`). Set ZERION_API_KEY or use --x402 for pay-per-call."
+license: MIT
+allowed-tools: Bash
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - zerion-cli
+    install:
+      - kind: node
+        package: "zerion-cli"
+        bins: [zerion-cli]
+    homepage: https://github.com/zeriontech/zerion-ai
+---
+
+# Chains
+
+List supported blockchain networks using zerion-cli.
+
+## Setup check
+
+```bash
+which zerion-cli || npm install -g zerion-cli
+```
+
+## Command
+
+```bash
+zerion-cli chains list [--x402]
+```
+
+Returns the full list of supported chains with IDs and metadata.
+
+## When to use
+
+- User asks "what chains does Zerion support?"
+- You need to validate a chain ID before passing `--chain` to wallet commands
+- Looking up chain metadata (name, type, support level)
+
+## Quick reference (common chain IDs)
+
+These chain IDs work with `--chain` in wallet commands:
+
+| Chain | ID |
+|-------|----|
+| Ethereum | `ethereum` |
+| Base | `base` |
+| Arbitrum | `arbitrum` |
+| Optimism | `optimism` |
+| Polygon | `polygon` |
+| BNB Chain | `bsc` |
+| Avalanche | `avalanche` |
+| Gnosis | `gnosis` |
+| Scroll | `scroll` |
+| Linea | `linea` |
+| zkSync | `zksync` |
+| Solana | `solana` |
+| Zora | `zora` |
+| Blast | `blast` |
+
+50+ chains are supported in total. Run `zerion-cli chains list` for the complete list.
+
+## Using with wallet commands
+
+```bash
+# Positions on a specific chain
+zerion-cli wallet positions <address> --chain ethereum
+
+# Transactions on a specific chain
+zerion-cli wallet transactions <address> --chain base
+
+# Full analysis filtered to one chain
+zerion-cli wallet analyze <address> --chain arbitrum
+```

--- a/skills/chains/SKILL.md
+++ b/skills/chains/SKILL.md
@@ -32,17 +32,17 @@ which zerion-cli || npm install -g zerion-cli
 zerion-cli chains list [--x402]
 ```
 
-Returns the full list of supported chains with IDs and metadata.
+Returns the full chain catalog with IDs and metadata.
 
 ## When to use
 
 - User asks "what chains does Zerion support?"
-- You need to validate a chain ID before passing `--chain` to wallet commands
+- You need the current chain catalog before choosing a `--chain` value
 - Looking up chain metadata (name, type, support level)
 
 ## Quick reference (common chain IDs)
 
-These chain IDs work with `--chain` in wallet commands:
+These are the chain IDs currently accepted by the wallet commands in this repo:
 
 | Chain | ID |
 |-------|----|
@@ -61,7 +61,7 @@ These chain IDs work with `--chain` in wallet commands:
 | Zora | `zora` |
 | Blast | `blast` |
 
-50+ chains are supported in total. Run `zerion-cli chains list` for the complete list.
+`zerion-cli chains list` may return a broader catalog. For `wallet positions`, `wallet transactions`, and `wallet analyze`, use the IDs above unless the CLI validator is expanded.
 
 ## Using with wallet commands
 

--- a/skills/wallet-analysis/EXAMPLES.md
+++ b/skills/wallet-analysis/EXAMPLES.md
@@ -1,0 +1,63 @@
+# Wallet Analysis Examples
+
+## Full wallet analysis
+
+```bash
+zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
+```
+
+Returns portfolio total, top 10 positions, 5 recent transactions, and PnL -- all in one call.
+
+## Full analysis with x402 (no API key)
+
+```bash
+zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --x402
+```
+
+## DeFi positions only
+
+```bash
+zerion-cli wallet positions 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --positions defi
+```
+
+Returns only DeFi protocol positions (staking, lending, LP, borrowed).
+
+## Positions on a specific chain
+
+```bash
+zerion-cli wallet positions 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --chain base
+```
+
+## Transaction history with custom limit
+
+```bash
+zerion-cli wallet transactions 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --limit 25
+```
+
+## Chain-specific transactions
+
+```bash
+zerion-cli wallet transactions 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --chain ethereum --limit 20
+```
+
+## Portfolio overview only
+
+```bash
+zerion-cli wallet portfolio 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
+```
+
+Returns total value, chain breakdown, and 1-day change.
+
+## PnL only
+
+```bash
+zerion-cli wallet pnl 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
+```
+
+Returns realized/unrealized gains, total invested, fees.
+
+## Example wallets
+
+- `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045` -- vitalik.eth
+- `0xFe89Cc7Abb2C4183683Ab71653c4cCd1b9cC194e` -- ENS DAO treasury
+- `0x25F2226B597E8F9514B3F68F00F494CF4F286491` -- Aave collector

--- a/skills/wallet-analysis/LICENSE.txt
+++ b/skills/wallet-analysis/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Zerion
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/wallet-analysis/SKILL.md
+++ b/skills/wallet-analysis/SKILL.md
@@ -1,80 +1,142 @@
 ---
 name: wallet-analysis
-description: Analyze a wallet using Zerion's hosted MCP or the zerion-cli. Summarize portfolio value, positions, transactions, and PnL in a clear read-only report.
+description: "Analyze any crypto wallet: portfolio value, token holdings, DeFi positions, transactions, and PnL. Supports 50+ EVM chains and Solana."
+compatibility: "Requires zerion-cli (`npx zerion-cli` or `npm install -g zerion-cli`). Set ZERION_API_KEY or use --x402 for pay-per-call."
+license: MIT
+allowed-tools: Bash
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - zerion-cli
+    install:
+      - kind: node
+        package: "zerion-cli"
+        bins: [zerion-cli]
+    homepage: https://github.com/zeriontech/zerion-ai
 ---
 
 # Wallet Analysis
 
-Use this skill for fast, read-only wallet analysis.
+Analyze crypto wallets using the zerion-cli. Returns structured JSON with portfolio overview, top positions, recent transactions, and PnL.
 
-## Inputs
-
-- wallet query: address or ENS name
-- optional chain filter when the user wants chain-specific context
-- optional position filter: `all` (default, both tokens and DeFi), `simple` (wallet tokens only), `defi` (DeFi protocol positions only)
-
-## Workflow
-
-1. Resolve the wallet query if the runtime supports name resolution.
-2. Fetch portfolio overview.
-3. Fetch wallet positions.
-4. Fetch recent transactions.
-5. Fetch wallet PnL.
-6. Summarize:
-   - total portfolio context
-   - top holdings
-   - DeFi exposure
-   - recent activity
-   - PnL highlights
-
-## MCP-first usage
-
-If the environment supports MCP, prefer the hosted Zerion MCP and ask directly for wallet analysis.
-
-## CLI-first usage
-
-If the environment expects commands, run:
+## Setup check
 
 ```bash
-# With x402 (no API key needed, pay $0.01 USDC per request)
-zerion-cli wallet analyze <wallet> --x402
-
-# With API key
-zerion-cli wallet analyze <wallet>
-zerion-cli wallet analyze <wallet> --positions defi
-```
-
-Or fetch the pieces explicitly:
-
-```bash
-zerion-cli wallet portfolio <wallet> [--x402]
-zerion-cli wallet positions <wallet> [--x402]
-zerion-cli wallet positions <wallet> --positions defi [--x402]
-zerion-cli wallet transactions <wallet> --limit 10 [--x402]
-zerion-cli wallet pnl <wallet> [--x402]
+which zerion-cli || npm install -g zerion-cli
 ```
 
 ## Authentication
 
 Two options:
 
-1. **x402 pay-per-call** - No signup, pay $0.01 USDC per request on Base. Set `WALLET_PRIVATE_KEY` to an EVM private key with USDC on Base, then use the `--x402` flag or `ZERION_X402=true`.
-2. **API key** - Get from [dashboard.zerion.io](https://dashboard.zerion.io). Higher rate limits for production.
+### API key (recommended for production)
 
-## Output
+```bash
+export ZERION_API_KEY="zk_dev_..."
+```
 
-Return a concise read-only report covering:
+Get yours at [dashboard.zerion.io](https://dashboard.zerion.io). Rate limits: 120 req/min, 5K req/day.
 
-- wallet identifier
-- total portfolio context
-- notable positions
-- notable transactions
-- PnL
-- any data limitations or failures
+### x402 pay-per-call (no signup)
 
-## Guardrails
+```bash
+zerion-cli wallet analyze <address> --x402
+```
 
-- read-only only
-- do not fabricate unsupported chains or positions
-- if data is missing or upstream is rate-limited, say that explicitly
-- prefer addresses in examples when client-side ENS support is uncertain
+Pays $0.01 USDC per request on Base. No API key needed -- the agent's wallet handles payment automatically via the [x402 protocol](https://www.x402.org/).
+
+## When to use
+
+Use this skill when the user asks about:
+- Wallet balances or portfolio value
+- Token holdings or DeFi positions
+- Transaction history or recent activity
+- Profit and loss (PnL)
+- What chains a wallet is active on
+
+## Commands
+
+### Full analysis (recommended starting point)
+
+```bash
+zerion-cli wallet analyze <address> [--positions all|simple|defi] [--chain <chain>] [--limit <n>] [--x402]
+```
+
+Fetches portfolio, positions, transactions, and PnL in parallel. Returns a structured summary with:
+- Portfolio total + chain breakdown + 1-day change
+- Top 10 positions by value (name, symbol, value, quantity, chain)
+- 5 most recent transactions with parsed transfers
+- PnL summary (realized, unrealized, total)
+
+### Portfolio overview
+
+```bash
+zerion-cli wallet portfolio <address> [--x402]
+```
+
+Total wallet value, breakdown by chain, and 1-day change.
+
+### Positions (token holdings + DeFi)
+
+```bash
+zerion-cli wallet positions <address> [--chain <chain>] [--positions all|simple|defi] [--x402]
+```
+
+Position filters:
+- `all` (default) -- wallet tokens + DeFi positions
+- `simple` -- wallet token balances only
+- `defi` -- DeFi protocol positions only (staked, deposited, LP, borrowed)
+
+### Transaction history
+
+```bash
+zerion-cli wallet transactions <address> [--limit <n>] [--chain <chain>] [--x402]
+```
+
+Returns interpreted transactions with parsed actions (trade, receive, send, mint, approve, etc.). Default limit: 10.
+
+### Profit and loss
+
+```bash
+zerion-cli wallet pnl <address> [--x402]
+```
+
+Realized gains, unrealized gains, total invested, fees, and relative percentages.
+
+## Typical workflow
+
+1. Check CLI: `which zerion-cli || npm install -g zerion-cli`
+2. Run full analysis: `zerion-cli wallet analyze <address>`
+3. If the user wants detail on a specific area, use individual commands:
+   - DeFi-only: `zerion-cli wallet positions <address> --positions defi`
+   - Chain-specific: `zerion-cli wallet positions <address> --chain ethereum`
+   - More transactions: `zerion-cli wallet transactions <address> --limit 25`
+
+## Output format
+
+All output is JSON on stdout. Errors are JSON on stderr with `{ "error": { "code": "...", "message": "..." } }`.
+
+## Supported chains
+
+ethereum, base, arbitrum, optimism, polygon, bsc, avalanche, gnosis, scroll, linea, zksync, solana, zora, blast -- and 40+ more EVM chains.
+
+Use `zerion-cli chains list` to see the full list.
+
+## Best practices
+
+1. **Start with `wallet analyze`** -- it fetches everything in parallel and returns a concise summary
+2. **Use individual commands for targeted queries** -- e.g., `wallet positions --positions defi` when the user only cares about DeFi
+3. **Address format**: use 0x hex addresses. ENS names are not currently supported by the API -- resolve them first
+4. **Chain filter**: use `--chain` to narrow results when the user mentions a specific chain
+5. **Rate limits**: 120 req/min with API key. Use `--x402` as fallback if rate-limited
+
+## Troubleshooting
+
+- **`missing_api_key`**: Set `ZERION_API_KEY` or add `--x402` flag
+- **`unsupported_chain`**: Run `zerion-cli chains list` to check valid chain IDs
+- **Empty positions/transactions**: Wallet may be inactive or very new
+- **`api_error` with status 429**: Rate limited -- wait or switch to x402
+- **ENS names fail with 400**: Resolve ENS to a hex address before querying
+
+For worked examples, see [EXAMPLES.md](EXAMPLES.md).

--- a/skills/wallet-analysis/SKILL.md
+++ b/skills/wallet-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wallet-analysis
-description: "Analyze any crypto wallet: portfolio value, token holdings, DeFi positions, transactions, and PnL. Supports 50+ EVM chains and Solana."
+description: "Analyze any crypto wallet: portfolio value, token holdings, DeFi positions, transactions, and PnL. Supports ENS names and the chain IDs currently accepted by zerion-cli."
 compatibility: "Requires zerion-cli (`npx zerion-cli` or `npm install -g zerion-cli`). Set ZERION_API_KEY or use --x402 for pay-per-call."
 license: MIT
 allowed-tools: Bash
@@ -119,15 +119,15 @@ All output is JSON on stdout. Errors are JSON on stderr with `{ "error": { "code
 
 ## Supported chains
 
-ethereum, base, arbitrum, optimism, polygon, bsc, avalanche, gnosis, scroll, linea, zksync, solana, zora, blast -- and 40+ more EVM chains.
+ethereum, base, arbitrum, optimism, polygon, bsc, avalanche, gnosis, scroll, linea, zksync, solana, zora, blast.
 
-Use `zerion-cli chains list` to see the full list.
+Use `zerion-cli chains list` to inspect the broader chain catalog, but stick to the IDs above for `--chain` unless the CLI validator is expanded.
 
 ## Best practices
 
 1. **Start with `wallet analyze`** -- it fetches everything in parallel and returns a concise summary
 2. **Use individual commands for targeted queries** -- e.g., `wallet positions --positions defi` when the user only cares about DeFi
-3. **Address format**: use 0x hex addresses. ENS names are not currently supported by the API -- resolve them first
+3. **Address format**: prefer 0x hex addresses for deterministic input, but ENS names also work when upstream resolution succeeds
 4. **Chain filter**: use `--chain` to narrow results when the user mentions a specific chain
 5. **Rate limits**: 120 req/min with API key. Use `--x402` as fallback if rate-limited
 
@@ -137,6 +137,6 @@ Use `zerion-cli chains list` to see the full list.
 - **`unsupported_chain`**: Run `zerion-cli chains list` to check valid chain IDs
 - **Empty positions/transactions**: Wallet may be inactive or very new
 - **`api_error` with status 429**: Rate limited -- wait or switch to x402
-- **ENS names fail with 400**: Resolve ENS to a hex address before querying
+- **ENS name fails**: Retry with the resolved 0x address if upstream name resolution is unavailable
 
 For worked examples, see [EXAMPLES.md](EXAMPLES.md).

--- a/skills/zerion-cli/LICENSE.txt
+++ b/skills/zerion-cli/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Zerion
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/zerion-cli/SKILL.md
+++ b/skills/zerion-cli/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: zerion-cli
+description: "Install, configure, and troubleshoot the Zerion CLI for crypto wallet data. Use when setting up authentication, checking CLI status, or debugging connection issues. For actual wallet queries, use the wallet-analysis skill."
+compatibility: "Requires Node.js >= 20."
+license: MIT
+allowed-tools: Bash
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - zerion-cli
+    install:
+      - kind: node
+        package: "zerion-cli"
+        bins: [zerion-cli]
+    homepage: https://github.com/zeriontech/zerion-ai
+---
+
+# Zerion CLI
+
+Setup, authentication, and troubleshooting for zerion-cli.
+
+**For wallet analysis, use the `wallet-analysis` skill instead.**
+
+## Installation
+
+```bash
+# Run without installing (recommended)
+npx zerion-cli --help
+
+# Or install globally
+npm install -g zerion-cli
+```
+
+Requires Node.js 20 or later.
+
+## Authentication
+
+### Option A: API key (recommended for production)
+
+```bash
+export ZERION_API_KEY="zk_dev_..."
+```
+
+Get yours at [dashboard.zerion.io](https://dashboard.zerion.io).
+
+- Dev keys start with `zk_dev_`
+- Rate limits: 120 requests/minute, 5,000 requests/day
+- Auth method: HTTP Basic Auth (key as username, empty password)
+
+### Option B: x402 pay-per-call (no signup)
+
+No API key needed. Pay $0.01 USDC per request on Base via the [x402 protocol](https://www.x402.org/).
+
+```bash
+# Per-command flag
+zerion-cli wallet analyze <address> --x402
+
+# Or set globally via environment
+export ZERION_X402=true
+```
+
+The agent's wallet handles payment automatically.
+
+## Environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `ZERION_API_KEY` | Yes (unless x402) | API key from dashboard.zerion.io |
+| `ZERION_X402` | No | Set to `true` to enable x402 pay-per-call globally |
+| `ZERION_API_BASE` | No | Override API base URL (default: `https://api.zerion.io/v1`) |
+
+## CLI help
+
+```bash
+zerion-cli --help
+```
+
+Returns JSON with all available commands, env vars, and x402 info.
+
+## Available commands
+
+```
+zerion-cli wallet analyze <address>       # Full wallet analysis
+zerion-cli wallet portfolio <address>     # Portfolio overview
+zerion-cli wallet positions <address>     # Token + DeFi positions
+zerion-cli wallet transactions <address>  # Transaction history
+zerion-cli wallet pnl <address>           # Profit and loss
+zerion-cli chains list                    # Supported chains
+```
+
+All commands accept `--x402` for pay-per-call auth.
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `missing_api_key` | No `ZERION_API_KEY` set | Set the env var or use `--x402` |
+| `unsupported_chain` | Invalid `--chain` value | Run `zerion-cli chains list` for valid IDs |
+| `api_error` status 401 | Invalid API key | Check key at dashboard.zerion.io |
+| `api_error` status 429 | Rate limited | Wait, reduce request frequency, or use x402 |
+| `api_error` status 400 | Invalid address format | Use 0x hex address, not ENS name |
+| `unexpected_error` | Node.js version too old | Requires Node.js >= 20 |
+
+## Resources
+
+- API docs: [developers.zerion.io](https://developers.zerion.io)
+- Dashboard: [dashboard.zerion.io](https://dashboard.zerion.io)
+- x402 protocol: [x402.org](https://www.x402.org/)
+- Source: [github.com/zeriontech/zerion-ai](https://github.com/zeriontech/zerion-ai)

--- a/skills/zerion-cli/SKILL.md
+++ b/skills/zerion-cli/SKILL.md
@@ -53,6 +53,9 @@ Get yours at [dashboard.zerion.io](https://dashboard.zerion.io).
 No API key needed. Pay $0.01 USDC per request on Base via the [x402 protocol](https://www.x402.org/).
 
 ```bash
+# Required for x402 payments
+export WALLET_PRIVATE_KEY="0x..."
+
 # Per-command flag
 zerion-cli wallet analyze <address> --x402
 
@@ -60,13 +63,14 @@ zerion-cli wallet analyze <address> --x402
 export ZERION_X402=true
 ```
 
-The agent's wallet handles payment automatically.
+The agent's wallet handles payment automatically using `WALLET_PRIVATE_KEY`.
 
 ## Environment variables
 
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `ZERION_API_KEY` | Yes (unless x402) | API key from dashboard.zerion.io |
+| `WALLET_PRIVATE_KEY` | Yes (for x402) | EVM private key for the wallet paying x402 requests on Base |
 | `ZERION_X402` | No | Set to `true` to enable x402 pay-per-call globally |
 | `ZERION_API_BASE` | No | Override API base URL (default: `https://api.zerion.io/v1`) |
 
@@ -99,7 +103,8 @@ All commands accept `--x402` for pay-per-call auth.
 | `unsupported_chain` | Invalid `--chain` value | Run `zerion-cli chains list` for valid IDs |
 | `api_error` status 401 | Invalid API key | Check key at dashboard.zerion.io |
 | `api_error` status 429 | Rate limited | Wait, reduce request frequency, or use x402 |
-| `api_error` status 400 | Invalid address format | Use 0x hex address, not ENS name |
+| `api_error` status 400 | Invalid address or ENS resolution failed | Retry with a valid 0x hex address |
+| `unexpected_error` | `WALLET_PRIVATE_KEY` missing in x402 mode | Export the private key or disable x402 |
 | `unexpected_error` | Node.js version too old | Requires Node.js >= 20 |
 
 ## Resources

--- a/tests/examples.test.mjs
+++ b/tests/examples.test.mjs
@@ -82,7 +82,14 @@ describe("examples", () => {
 
     it("has valid Python syntax", () => {
       try {
-        execFileSync("python3", ["-m", "py_compile", join(ROOT, "examples/openai-agents/wallet_analysis.py")]);
+        execFileSync(
+          "python3",
+          [
+            "-c",
+            "import ast, pathlib, sys; ast.parse(pathlib.Path(sys.argv[1]).read_text())",
+            join(ROOT, "examples/openai-agents/wallet_analysis.py")
+          ]
+        );
       } catch (e) {
         // Skip if python3 is not available
         if (e.code === "ENOENT") {

--- a/tests/skills.test.mjs
+++ b/tests/skills.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+const skillsDir = join(ROOT, "skills");
+
+const EXPECTED_SKILLS = ["wallet-analysis", "chains", "zerion-cli"];
+
+const REQUIRED_FRONTMATTER = ["name", "description", "license", "allowed-tools"];
+
+function parseSkillFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+  const yaml = match[1];
+  const fields = {};
+  for (const line of yaml.split("\n")) {
+    const colonIndex = line.indexOf(":");
+    if (colonIndex === -1 || line.startsWith(" ") || line.startsWith("\t")) continue;
+    const key = line.slice(0, colonIndex).trim();
+    const value = line.slice(colonIndex + 1).trim();
+    fields[key] = value;
+  }
+  return { raw: yaml, fields };
+}
+
+describe("skills directory", () => {
+  it("has all expected skill directories", () => {
+    const dirs = readdirSync(skillsDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)
+      .sort();
+    for (const name of EXPECTED_SKILLS) {
+      assert.ok(dirs.includes(name), `Missing skill directory: ${name}`);
+    }
+  });
+
+  for (const skill of EXPECTED_SKILLS) {
+    describe(skill, () => {
+      const skillDir = join(skillsDir, skill);
+
+      it("has SKILL.md", () => {
+        assert.ok(existsSync(join(skillDir, "SKILL.md")));
+      });
+
+      it("has LICENSE.txt", () => {
+        assert.ok(existsSync(join(skillDir, "LICENSE.txt")));
+      });
+
+      it("SKILL.md has valid frontmatter with required fields", () => {
+        const content = readFileSync(join(skillDir, "SKILL.md"), "utf8");
+        const fm = parseSkillFrontmatter(content);
+        assert.ok(fm, "SKILL.md must have YAML frontmatter");
+        for (const field of REQUIRED_FRONTMATTER) {
+          assert.ok(fm.fields[field], `Missing frontmatter field: ${field}`);
+        }
+      });
+
+      it("frontmatter name matches directory name", () => {
+        const content = readFileSync(join(skillDir, "SKILL.md"), "utf8");
+        const fm = parseSkillFrontmatter(content);
+        assert.equal(fm.fields.name, skill);
+      });
+
+      it("frontmatter declares zerion-cli as openclaw dependency", () => {
+        const content = readFileSync(join(skillDir, "SKILL.md"), "utf8");
+        assert.ok(
+          content.includes('package: "zerion-cli"'),
+          "Must declare zerion-cli as openclaw install package"
+        );
+      });
+    });
+  }
+});
+
+describe("wallet-analysis extras", () => {
+  it("has EXAMPLES.md", () => {
+    assert.ok(existsSync(join(skillsDir, "wallet-analysis", "EXAMPLES.md")));
+  });
+
+  it("EXAMPLES.md contains example wallet addresses", () => {
+    const content = readFileSync(
+      join(skillsDir, "wallet-analysis", "EXAMPLES.md"),
+      "utf8"
+    );
+    assert.match(content, /0x[a-fA-F0-9]{40}/);
+  });
+});

--- a/tests/skills.test.mjs
+++ b/tests/skills.test.mjs
@@ -88,4 +88,26 @@ describe("wallet-analysis extras", () => {
     );
     assert.match(content, /0x[a-fA-F0-9]{40}/);
   });
+
+  it("documents ENS names as supported input", () => {
+    const content = readFileSync(
+      join(skillsDir, "wallet-analysis", "SKILL.md"),
+      "utf8"
+    );
+    assert.match(content, /ENS names also work/i);
+    assert.doesNotMatch(content, /ENS names are not currently supported/i);
+  });
+});
+
+describe("skill guidance consistency", () => {
+  it("documents WALLET_PRIVATE_KEY for x402 in zerion-cli skill", () => {
+    const content = readFileSync(join(skillsDir, "zerion-cli", "SKILL.md"), "utf8");
+    assert.match(content, /WALLET_PRIVATE_KEY/);
+  });
+
+  it("does not claim wallet commands accept more chains than the CLI validator", () => {
+    const content = readFileSync(join(skillsDir, "chains", "SKILL.md"), "utf8");
+    assert.match(content, /currently accepted by the wallet commands/i);
+    assert.doesNotMatch(content, /50\+\s+chains are supported/i);
+  });
 });


### PR DESCRIPTION
## Summary

- Restructures `skills/` so `npx skills add zeriontech/zerion-ai` discovers all capabilities
- Adds 3 skills following the [browserbase/skills](https://github.com/browserbase/skills) pattern:
  - **wallet-analysis** – full wallet data queries (analyze, portfolio, positions, transactions, pnl) with all CLI commands documented
  - **chains** – supported blockchain networks reference
  - **zerion-cli** – CLI setup, authentication (API key + x402), and troubleshooting
- Each SKILL.md has proper `metadata.openclaw.install` frontmatter declaring `zerion-cli` as the npm dependency
- Adds EXAMPLES.md, LICENSE.txt per skill, `tests/skills.test.mjs` for frontmatter validation
- Updates README with `npx skills add zeriontech/zerion-ai` install instructions

Previously only 1 skill was discoverable and it lacked the frontmatter needed for automatic CLI installation.

## Test plan

- [x] All 141 tests pass (14 integration tests skipped without API key)
- [ ] `npx skills add zeriontech/zerion-ai --list` shows 3 skills
- [ ] Skills install correctly into `.claude/skills/` with proper symlinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)