### PR TITLE
feat: add Solana support for x402 pay-per-call

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,21 @@ Useful docs:
 
 ### Option B: x402 Pay-per-call
 
-**No API key needed.** Pay $0.01 USDC per request via the [x402 protocol](https://www.x402.org/). Supports EVM (Base) and Solana — the key format is auto-detected. The CLI handles the payment handshake automatically using your wallet's private key.
+**No API key needed.** Pay $0.01 USDC per request via the [x402 protocol](https://www.x402.org/). Supports EVM (Base) and Solana. The CLI handles the payment handshake automatically.
 
-Setup:
+**Single key** — format is auto-detected:
 
 ```bash
-# EVM (Base) — 0x-prefixed hex
-export WALLET_PRIVATE_KEY="0x..."
+export WALLET_PRIVATE_KEY="0x..."    # EVM (Base) — 0x-prefixed hex
+export WALLET_PRIVATE_KEY="5C1y..."  # Solana — base58 encoded keypair
+```
 
-# Solana — base58 encoded keypair
-export WALLET_PRIVATE_KEY="5C1y..."
+**Both chains simultaneously:**
+
+```bash
+export EVM_PRIVATE_KEY="0x..."
+export SOLANA_PRIVATE_KEY="5C1y..."
+export ZERION_X402_PREFER_SOLANA=true  # optional: prefer Solana when both are set
 ```
 
 Then use the `--x402` flag:

--- a/README.md
+++ b/README.md
@@ -36,12 +36,16 @@ Useful docs:
 
 ### Option B: x402 Pay-per-call
 
-**No API key needed.** Pay $0.01 USDC per request on Base via the [x402 protocol](https://www.x402.org/). The CLI handles the payment handshake automatically using your wallet's private key.
+**No API key needed.** Pay $0.01 USDC per request via the [x402 protocol](https://www.x402.org/). Supports EVM (Base) and Solana — the key format is auto-detected. The CLI handles the payment handshake automatically using your wallet's private key.
 
 Setup:
 
 ```bash
-export WALLET_PRIVATE_KEY="0x..."   # EVM wallet with USDC on Base
+# EVM (Base) — 0x-prefixed hex
+export WALLET_PRIVATE_KEY="0x..."
+
+# Solana — base58 encoded keypair
+export WALLET_PRIVATE_KEY="5C1y..."
 ```
 
 Then use the `--x402` flag:
@@ -131,7 +135,7 @@ zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
 
 ```bash
 npm install -g zerion-cli
-export WALLET_PRIVATE_KEY="0x..."
+export WALLET_PRIVATE_KEY="0x..."   # or base58 for Solana
 zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --x402
 ```
 

--- a/cli/zerion-cli.js
+++ b/cli/zerion-cli.js
@@ -7,6 +7,9 @@ const DEFAULT_TX_LIMIT = 10;
 const API_KEY = process.env.ZERION_API_KEY || "";
 const USE_X402 = process.env.ZERION_X402 === "true";
 const WALLET_PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY || "";
+const EVM_PRIVATE_KEY = process.env.EVM_PRIVATE_KEY || "";
+const SOLANA_PRIVATE_KEY = process.env.SOLANA_PRIVATE_KEY || "";
+const PREFER_SOLANA = process.env.ZERION_X402_PREFER_SOLANA === "true";
 
 let debug = false;
 function debugLog(...args) {
@@ -41,27 +44,45 @@ function base58ToBytes(str) {
 let _x402Fetch = null;
 async function getX402Fetch() {
   if (_x402Fetch) return _x402Fetch;
-  if (!WALLET_PRIVATE_KEY) {
-    throw new Error("WALLET_PRIVATE_KEY is required for x402 mode. Set it as an environment variable.");
+
+  // Resolve keys: dedicated vars take precedence, fall back to WALLET_PRIVATE_KEY
+  const evmKey = EVM_PRIVATE_KEY || (isEvmKey(WALLET_PRIVATE_KEY) ? WALLET_PRIVATE_KEY : "");
+  const solKey = SOLANA_PRIVATE_KEY || (isSolanaKey(WALLET_PRIVATE_KEY) ? WALLET_PRIVATE_KEY : "");
+
+  if (!evmKey && !solKey) {
+    throw new Error(
+      "No valid private key found for x402 mode. Set WALLET_PRIVATE_KEY (0x-hex for EVM, base58 for Solana), " +
+      "or set EVM_PRIVATE_KEY and/or SOLANA_PRIVATE_KEY."
+    );
   }
+
   const { wrapFetchWithPayment, x402Client } = await import("@x402/fetch");
   const client = new x402Client();
 
-  if (isEvmKey(WALLET_PRIVATE_KEY)) {
+  if (evmKey) {
     const { registerExactEvmScheme } = await import("@x402/evm/exact/client");
     const { privateKeyToAccount } = await import("viem/accounts");
-    const signer = privateKeyToAccount(WALLET_PRIVATE_KEY);
+    const signer = privateKeyToAccount(evmKey);
     registerExactEvmScheme(client, { signer });
-    debugLog("x402 mode: EVM (Base)");
-  } else if (isSolanaKey(WALLET_PRIVATE_KEY)) {
+    debugLog("x402 registered: EVM (Base)");
+  }
+
+  if (solKey) {
     const { registerExactSvmScheme } = await import("@x402/svm/exact/client");
     const { createKeyPairSignerFromBytes } = await import("@solana/kit");
-    const keyBytes = base58ToBytes(WALLET_PRIVATE_KEY);
+    const keyBytes = base58ToBytes(solKey);
     const signer = await createKeyPairSignerFromBytes(keyBytes);
     registerExactSvmScheme(client, { signer });
-    debugLog(`x402 mode: Solana (${signer.address})`);
-  } else {
-    throw new Error("WALLET_PRIVATE_KEY format not recognized. Use 0x-prefixed hex for EVM or base58 for Solana.");
+    debugLog(`x402 registered: Solana (${signer.address})`);
+  }
+
+  if (evmKey && solKey && PREFER_SOLANA) {
+    client.registerPolicy((version, reqs) => {
+      const sol = reqs.filter(r => r.network.startsWith("solana:"));
+      const others = reqs.filter(r => !r.network.startsWith("solana:"));
+      return [...sol, ...others];
+    });
+    debugLog("x402 policy: prefer Solana");
   }
 
   _x402Fetch = wrapFetchWithPayment(fetch, client);
@@ -87,7 +108,7 @@ function usage() {
       "zerion-cli wallet pnl <address> [--x402]",
       "zerion-cli chains list [--x402]"
     ],
-    env: ["ZERION_API_KEY", "ZERION_API_BASE (optional)", "ZERION_X402=true (use x402 pay-per-call)", "WALLET_PRIVATE_KEY (required for x402: 0x-hex for EVM, base58 for Solana)"],
+    env: ["ZERION_API_KEY", "ZERION_API_BASE (optional)", "ZERION_X402=true (use x402 pay-per-call)", "WALLET_PRIVATE_KEY (x402: single key, auto-detected format)", "EVM_PRIVATE_KEY (x402: 0x-hex EVM key, overrides WALLET_PRIVATE_KEY for EVM)", "SOLANA_PRIVATE_KEY (x402: base58 Solana key, overrides WALLET_PRIVATE_KEY for Solana)", "ZERION_X402_PREFER_SOLANA=true (prefer Solana when both keys are set)"],
     x402: {
       description: "Pay $0.01 USDC per request. EVM (Base) or Solana supported — auto-detected from key format.",
       docs: "https://developers.zerion.io/reference/x402"

--- a/cli/zerion-cli.js
+++ b/cli/zerion-cli.js
@@ -21,24 +21,9 @@ function isEvmKey(key) {
 }
 
 const BASE58_RE = /^[1-9A-HJ-NP-Za-km-z]+$/;
+// Solana keypairs are 64 bytes; base58-encoded they are 87-88 characters
 function isSolanaKey(key) {
-  return !key.startsWith("0x") && BASE58_RE.test(key) && key.length >= 64;
-}
-
-function base58ToBytes(str) {
-  const ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-  const bytes = [];
-  for (const c of str) {
-    let carry = ALPHABET.indexOf(c);
-    for (let j = 0; j < bytes.length; j++) {
-      carry += bytes[j] * 58;
-      bytes[j] = carry & 0xff;
-      carry >>= 8;
-    }
-    while (carry > 0) { bytes.push(carry & 0xff); carry >>= 8; }
-  }
-  for (const c of str) { if (c === "1") bytes.push(0); else break; }
-  return new Uint8Array(bytes.reverse());
+  return !key.startsWith("0x") && BASE58_RE.test(key) && key.length >= 80;
 }
 
 let _x402Fetch = null;
@@ -60,6 +45,9 @@ async function getX402Fetch() {
   const client = new x402Client();
 
   if (evmKey) {
+    if (!isEvmKey(evmKey)) {
+      throw new Error("EVM_PRIVATE_KEY must be a 0x-prefixed hex string.");
+    }
     const { registerExactEvmScheme } = await import("@x402/evm/exact/client");
     const { privateKeyToAccount } = await import("viem/accounts");
     const signer = privateKeyToAccount(evmKey);
@@ -69,8 +57,8 @@ async function getX402Fetch() {
 
   if (solKey) {
     const { registerExactSvmScheme } = await import("@x402/svm/exact/client");
-    const { createKeyPairSignerFromBytes } = await import("@solana/kit");
-    const keyBytes = base58ToBytes(solKey);
+    const { createKeyPairSignerFromBytes, getBase58Codec } = await import("@solana/kit");
+    const keyBytes = getBase58Codec().encode(solKey);
     const signer = await createKeyPairSignerFromBytes(keyBytes);
     registerExactSvmScheme(client, { signer });
     debugLog(`x402 registered: Solana (${signer.address})`);
@@ -160,8 +148,9 @@ async function fetchAPI(pathname, params = {}, useX402 = false) {
   const fetchFn = useX402 ? await getX402Fetch() : fetch;
   let response = await fetchFn(url, { headers });
 
-  // Retry on x402 402 (Solana facilitator fee-payer rotation can cause transient failures)
-  for (let attempt = 1; useX402 && response.status === 402 && attempt <= 2; attempt++) {
+  // Retry on 402 only for Solana — facilitator fee-payer rotation can cause transient failures
+  const hasSolanaKey = !!(SOLANA_PRIVATE_KEY || isSolanaKey(WALLET_PRIVATE_KEY));
+  for (let attempt = 1; useX402 && hasSolanaKey && response.status === 402 && attempt <= 2; attempt++) {
     debugLog(`x402 payment failed, retry ${attempt}/2...`);
     response = await fetchFn(url, { headers });
   }

--- a/cli/zerion-cli.js
+++ b/cli/zerion-cli.js
@@ -13,6 +13,31 @@ function debugLog(...args) {
   if (debug) process.stderr.write(`[debug] ${args.join(" ")}\n`);
 }
 
+function isEvmKey(key) {
+  return key.startsWith("0x");
+}
+
+const BASE58_RE = /^[1-9A-HJ-NP-Za-km-z]+$/;
+function isSolanaKey(key) {
+  return !key.startsWith("0x") && BASE58_RE.test(key) && key.length >= 64;
+}
+
+function base58ToBytes(str) {
+  const ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+  const bytes = [];
+  for (const c of str) {
+    let carry = ALPHABET.indexOf(c);
+    for (let j = 0; j < bytes.length; j++) {
+      carry += bytes[j] * 58;
+      bytes[j] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) { bytes.push(carry & 0xff); carry >>= 8; }
+  }
+  for (const c of str) { if (c === "1") bytes.push(0); else break; }
+  return new Uint8Array(bytes.reverse());
+}
+
 let _x402Fetch = null;
 async function getX402Fetch() {
   if (_x402Fetch) return _x402Fetch;
@@ -20,11 +45,25 @@ async function getX402Fetch() {
     throw new Error("WALLET_PRIVATE_KEY is required for x402 mode. Set it as an environment variable.");
   }
   const { wrapFetchWithPayment, x402Client } = await import("@x402/fetch");
-  const { registerExactEvmScheme } = await import("@x402/evm/exact/client");
-  const { privateKeyToAccount } = await import("viem/accounts");
-  const signer = privateKeyToAccount(WALLET_PRIVATE_KEY);
   const client = new x402Client();
-  registerExactEvmScheme(client, { signer });
+
+  if (isEvmKey(WALLET_PRIVATE_KEY)) {
+    const { registerExactEvmScheme } = await import("@x402/evm/exact/client");
+    const { privateKeyToAccount } = await import("viem/accounts");
+    const signer = privateKeyToAccount(WALLET_PRIVATE_KEY);
+    registerExactEvmScheme(client, { signer });
+    debugLog("x402 mode: EVM (Base)");
+  } else if (isSolanaKey(WALLET_PRIVATE_KEY)) {
+    const { registerExactSvmScheme } = await import("@x402/svm/exact/client");
+    const { createKeyPairSignerFromBytes } = await import("@solana/kit");
+    const keyBytes = base58ToBytes(WALLET_PRIVATE_KEY);
+    const signer = await createKeyPairSignerFromBytes(keyBytes);
+    registerExactSvmScheme(client, { signer });
+    debugLog(`x402 mode: Solana (${signer.address})`);
+  } else {
+    throw new Error("WALLET_PRIVATE_KEY format not recognized. Use 0x-prefixed hex for EVM or base58 for Solana.");
+  }
+
   _x402Fetch = wrapFetchWithPayment(fetch, client);
   return _x402Fetch;
 }
@@ -48,9 +87,9 @@ function usage() {
       "zerion-cli wallet pnl <address> [--x402]",
       "zerion-cli chains list [--x402]"
     ],
-    env: ["ZERION_API_KEY", "ZERION_API_BASE (optional)", "ZERION_X402=true (use x402 pay-per-call)", "WALLET_PRIVATE_KEY (required for x402)"],
+    env: ["ZERION_API_KEY", "ZERION_API_BASE (optional)", "ZERION_X402=true (use x402 pay-per-call)", "WALLET_PRIVATE_KEY (required for x402: 0x-hex for EVM, base58 for Solana)"],
     x402: {
-      description: "Pay $0.01 USDC per request on Base. No API key required.",
+      description: "Pay $0.01 USDC per request. EVM (Base) or Solana supported — auto-detected from key format.",
       docs: "https://developers.zerion.io/reference/x402"
     }
   });
@@ -98,7 +137,13 @@ async function fetchAPI(pathname, params = {}, useX402 = false) {
   debugLog(`${useX402 ? "x402" : "api"} GET ${url}`);
 
   const fetchFn = useX402 ? await getX402Fetch() : fetch;
-  const response = await fetchFn(url, { headers });
+  let response = await fetchFn(url, { headers });
+
+  // Retry on x402 402 (Solana facilitator fee-payer rotation can cause transient failures)
+  for (let attempt = 1; useX402 && response.status === 402 && attempt <= 2; attempt++) {
+    debugLog(`x402 payment failed, retry ${attempt}/2...`);
+    response = await fetchFn(url, { headers });
+  }
 
   debugLog(`response ${response.status} ${url}`);
 

--- a/cli/zerion-cli.js
+++ b/cli/zerion-cli.js
@@ -26,6 +26,8 @@ function isSolanaKey(key) {
   return !key.startsWith("0x") && BASE58_RE.test(key) && key.length >= 80;
 }
 
+const HAS_SOLANA_KEY = !!(SOLANA_PRIVATE_KEY || isSolanaKey(WALLET_PRIVATE_KEY));
+
 let _x402Fetch = null;
 async function getX402Fetch() {
   if (_x402Fetch) return _x402Fetch;
@@ -44,10 +46,11 @@ async function getX402Fetch() {
   const { wrapFetchWithPayment, x402Client } = await import("@x402/fetch");
   const client = new x402Client();
 
+  if (EVM_PRIVATE_KEY && !isEvmKey(EVM_PRIVATE_KEY)) {
+    throw new Error("EVM_PRIVATE_KEY must be a 0x-prefixed hex string.");
+  }
+
   if (evmKey) {
-    if (!isEvmKey(evmKey)) {
-      throw new Error("EVM_PRIVATE_KEY must be a 0x-prefixed hex string.");
-    }
     const { registerExactEvmScheme } = await import("@x402/evm/exact/client");
     const { privateKeyToAccount } = await import("viem/accounts");
     const signer = privateKeyToAccount(evmKey);
@@ -62,6 +65,10 @@ async function getX402Fetch() {
     const signer = await createKeyPairSignerFromBytes(keyBytes);
     registerExactSvmScheme(client, { signer });
     debugLog(`x402 registered: Solana (${signer.address})`);
+  }
+
+  if (PREFER_SOLANA && !(evmKey && solKey)) {
+    debugLog("x402 warning: ZERION_X402_PREFER_SOLANA=true has no effect unless both EVM and Solana keys are set");
   }
 
   if (evmKey && solKey && PREFER_SOLANA) {
@@ -149,8 +156,7 @@ async function fetchAPI(pathname, params = {}, useX402 = false) {
   let response = await fetchFn(url, { headers });
 
   // Retry on 402 only for Solana — facilitator fee-payer rotation can cause transient failures
-  const hasSolanaKey = !!(SOLANA_PRIVATE_KEY || isSolanaKey(WALLET_PRIVATE_KEY));
-  for (let attempt = 1; useX402 && hasSolanaKey && response.status === 402 && attempt <= 2; attempt++) {
+  for (let attempt = 1; useX402 && HAS_SOLANA_KEY && response.status === 402 && attempt <= 2; attempt++) {
     debugLog(`x402 payment failed, retry ${attempt}/2...`);
     response = await fetchFn(url, { headers });
   }

--- a/cli/zerion-cli.js
+++ b/cli/zerion-cli.js
@@ -43,12 +43,12 @@ async function getX402Fetch() {
     );
   }
 
-  const { wrapFetchWithPayment, x402Client } = await import("@x402/fetch");
-  const client = new x402Client();
-
   if (EVM_PRIVATE_KEY && !isEvmKey(EVM_PRIVATE_KEY)) {
     throw new Error("EVM_PRIVATE_KEY must be a 0x-prefixed hex string.");
   }
+
+  const { wrapFetchWithPayment, x402Client } = await import("@x402/fetch");
+  const client = new x402Client();
 
   if (evmKey) {
     const { registerExactEvmScheme } = await import("@x402/evm/exact/client");

--- a/docs/x402-endpoints.md
+++ b/docs/x402-endpoints.md
@@ -4,15 +4,26 @@ Pay-per-call API endpoints using the [x402 protocol](https://www.x402.org/). No 
 
 ## Prerequisites
 
-Set `WALLET_PRIVATE_KEY` to a private key whose address holds USDC. The key format is auto-detected:
+Configure at least one wallet key holding USDC. The CLI registers whichever schemes you provide and handles the payment handshake automatically.
+
+**Single key** — format is auto-detected:
 
 ```bash
-# EVM (Base) — 0x-prefixed hex
-export WALLET_PRIVATE_KEY="0x..."
-
-# Solana — base58 encoded keypair
-export WALLET_PRIVATE_KEY="5C1y..."
+export WALLET_PRIVATE_KEY="0x..."    # EVM (Base) — 0x-prefixed hex
+export WALLET_PRIVATE_KEY="5C1y..."  # Solana — base58 encoded keypair
 ```
+
+**Both chains simultaneously** — use dedicated variables:
+
+```bash
+export EVM_PRIVATE_KEY="0x..."       # EVM (Base)
+export SOLANA_PRIVATE_KEY="5C1y..."  # Solana
+
+# Optional: prefer Solana when the server offers both networks
+export ZERION_X402_PREFER_SOLANA=true
+```
+
+When both keys are set, the x402 client registers both schemes and selects the network based on what the server offers (defaulting to EVM unless `ZERION_X402_PREFER_SOLANA=true`).
 
 The CLI uses [`@x402/fetch`](https://www.npmjs.com/package/@x402/fetch) with [`@x402/evm`](https://www.npmjs.com/package/@x402/evm) or [`@x402/svm`](https://www.npmjs.com/package/@x402/svm) to handle the 402 payment handshake automatically.
 

--- a/docs/x402-endpoints.md
+++ b/docs/x402-endpoints.md
@@ -4,13 +4,17 @@ Pay-per-call API endpoints using the [x402 protocol](https://www.x402.org/). No 
 
 ## Prerequisites
 
-Set `WALLET_PRIVATE_KEY` to an EVM private key whose address holds USDC on Base:
+Set `WALLET_PRIVATE_KEY` to a private key whose address holds USDC. The key format is auto-detected:
 
 ```bash
+# EVM (Base) — 0x-prefixed hex
 export WALLET_PRIVATE_KEY="0x..."
+
+# Solana — base58 encoded keypair
+export WALLET_PRIVATE_KEY="5C1y..."
 ```
 
-The CLI uses [`@x402/fetch`](https://www.npmjs.com/package/@x402/fetch) and [`@x402/evm`](https://www.npmjs.com/package/@x402/evm) to handle the 402 payment handshake automatically.
+The CLI uses [`@x402/fetch`](https://www.npmjs.com/package/@x402/fetch) with [`@x402/evm`](https://www.npmjs.com/package/@x402/evm) or [`@x402/svm`](https://www.npmjs.com/package/@x402/svm) to handle the 402 payment handshake automatically.
 
 ## Base URL
 
@@ -82,9 +86,9 @@ zerion-cli wallet analyze 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
 
 ## Pricing
 
-- **$0.01 USDC per request** on Base
+- **$0.01 USDC per request** on Base (EVM) or Solana
 - Payment handled automatically via HTTP 402 protocol
-- Agent wallet must have USDC balance on Base
+- Agent wallet must have USDC balance on the corresponding network
 
 ## Learn More
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -38,15 +38,22 @@ This repo's example configs assume an `Authorization: Bearer ...` header for the
 
 ### Option 2: x402 Pay-per-call
 
-No API key needed. Pay $0.01 USDC per request via the [x402 protocol](https://www.x402.org/). Supports EVM (Base) and Solana — auto-detected from key format.
+No API key needed. Pay $0.01 USDC per request via the [x402 protocol](https://www.x402.org/). Supports EVM (Base) and Solana.
+
+**Single key** — format is auto-detected:
 
 ```bash
-# EVM (Base) — 0x-prefixed hex
-export WALLET_PRIVATE_KEY="0x..."
+export WALLET_PRIVATE_KEY="0x..."    # EVM (Base) — 0x-prefixed hex
+export WALLET_PRIVATE_KEY="5C1y..."  # Solana — base58 encoded keypair
+export ZERION_X402=true
+```
 
-# Solana — base58 encoded keypair
-export WALLET_PRIVATE_KEY="5C1y..."
+**Both chains simultaneously:**
 
+```bash
+export EVM_PRIVATE_KEY="0x..."
+export SOLANA_PRIVATE_KEY="5C1y..."
+export ZERION_X402_PREFER_SOLANA=true  # optional: prefer Solana when both are set
 export ZERION_X402=true
 ```
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -38,14 +38,19 @@ This repo's example configs assume an `Authorization: Bearer ...` header for the
 
 ### Option 2: x402 Pay-per-call
 
-No API key needed. Pay $0.01 USDC per request on Base via the [x402 protocol](https://www.x402.org/).
+No API key needed. Pay $0.01 USDC per request via the [x402 protocol](https://www.x402.org/). Supports EVM (Base) and Solana — auto-detected from key format.
 
 ```bash
-export WALLET_PRIVATE_KEY="0x..."   # EVM wallet with USDC on Base
+# EVM (Base) — 0x-prefixed hex
+export WALLET_PRIVATE_KEY="0x..."
+
+# Solana — base58 encoded keypair
+export WALLET_PRIVATE_KEY="5C1y..."
+
 export ZERION_X402=true
 ```
 
-The CLI signs the payment automatically using `@x402/fetch` and `@x402/evm`. Your wallet must hold USDC on Base.
+The CLI signs the payment automatically using `@x402/fetch` with `@x402/evm` or `@x402/svm`. Your wallet must hold USDC on the corresponding network.
 
 ## Supported clients in this repo
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1333 @@
+{
+  "name": "zerion-cli",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "zerion-cli",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@x402/evm": "^2.6.0",
+        "@x402/fetch": "^2.6.0",
+        "@x402/svm": "^2.8.0",
+        "viem": "^2.0.0"
+      },
+      "bin": {
+        "zerion-cli": "cli/zerion-cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@solana-program/compute-budget": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.11.0.tgz",
+      "integrity": "sha512-7f1ePqB/eURkTwTOO9TNIdUXZcyrZoX3Uy2hNo7cXMfNhPFWp9AVgIyRNBc2jf15sdUa9gNpW+PfP2iV8AYAaw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^5.0"
+      }
+    },
+    "node_modules/@solana-program/token": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.9.0.tgz",
+      "integrity": "sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^5.0"
+      }
+    },
+    "node_modules/@solana-program/token-2022": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/token-2022/-/token-2022-0.6.1.tgz",
+      "integrity": "sha512-Ex02cruDMGfBMvZZCrggVR45vdQQSI/unHVpt/7HPt/IwFYB4eTlXtO8otYZyqV/ce5GqZ8S6uwyRf0zy6fdbA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^5.0",
+        "@solana/sysvars": "^5.0"
+      }
+    },
+    "node_modules/@solana/accounts": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-5.5.1.tgz",
+      "integrity": "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/addresses": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-5.5.1.tgz",
+      "integrity": "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/assertions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-5.5.1.tgz",
+      "integrity": "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-5.5.1.tgz",
+      "integrity": "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/options": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-core": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-5.5.1.tgz",
+      "integrity": "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-data-structures": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-5.5.1.tgz",
+      "integrity": "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-numbers": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-5.5.1.tgz",
+      "integrity": "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-strings": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-5.5.1.tgz",
+      "integrity": "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/errors": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-5.5.1.tgz",
+      "integrity": "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.2"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/fast-stable-stringify": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-5.5.1.tgz",
+      "integrity": "sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/functional": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-5.5.1.tgz",
+      "integrity": "sha512-tTHoJcEQq3gQx5qsdsDJ0LEJeFzwNpXD80xApW9o/PPoCNimI3SALkZl+zNW8VnxRrV3l3yYvfHWBKe/X3WG3w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-5.5.1.tgz",
+      "integrity": "sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instructions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-5.5.1.tgz",
+      "integrity": "sha512-h0G1CG6S+gUUSt0eo6rOtsaXRBwCq1+Js2a+Ps9Bzk9q7YHNFA75/X0NWugWLgC92waRp66hrjMTiYYnLBoWOQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/keys": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-5.5.1.tgz",
+      "integrity": "sha512-KRD61cL7CRL+b4r/eB9dEoVxIf/2EJ1Pm1DmRYhtSUAJD2dJ5Xw8QFuehobOGm9URqQ7gaQl+Fkc1qvDlsWqKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
+      "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/accounts": "5.5.1",
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instruction-plans": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/offchain-messages": "5.5.1",
+        "@solana/plugin-core": "5.5.1",
+        "@solana/programs": "5.5.1",
+        "@solana/rpc": "5.5.1",
+        "@solana/rpc-api": "5.5.1",
+        "@solana/rpc-parsed-types": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-subscriptions": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/signers": "5.5.1",
+        "@solana/sysvars": "5.5.1",
+        "@solana/transaction-confirmation": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/nominal-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-5.5.1.tgz",
+      "integrity": "sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-5.5.1.tgz",
+      "integrity": "sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-5.5.1.tgz",
+      "integrity": "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-core": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-5.5.1.tgz",
+      "integrity": "sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-5.5.1.tgz",
+      "integrity": "sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/promises": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-5.5.1.tgz",
+      "integrity": "sha512-T9lfuUYkGykJmppEcssNiCf6yiYQxJkhiLPP+pyAc2z84/7r3UVIb2tNJk4A9sucS66pzJnVHZKcZVGUUp6wzA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-5.5.1.tgz",
+      "integrity": "sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/fast-stable-stringify": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/rpc-api": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-transport-http": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-5.5.1.tgz",
+      "integrity": "sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/rpc-parsed-types": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-parsed-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-5.5.1.tgz",
+      "integrity": "sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-5.5.1.tgz",
+      "integrity": "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-5.5.1.tgz",
+      "integrity": "sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-5.5.1.tgz",
+      "integrity": "sha512-CTMy5bt/6mDh4tc6vUJms9EcuZj3xvK0/xq8IQ90rhkpYvate91RjBP+egvjgSayUg9yucU9vNuUpEjz4spM7w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/fast-stable-stringify": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-subscriptions-api": "5.5.1",
+        "@solana/rpc-subscriptions-channel-websocket": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/subscribable": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-5.5.1.tgz",
+      "integrity": "sha512-5Oi7k+GdeS8xR2ly1iuSFkAv6CZqwG0Z6b1QZKbEgxadE1XGSDrhM2cn59l+bqCozUWCqh4c/A2znU/qQjROlw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-5.5.1.tgz",
+      "integrity": "sha512-7tGfBBrYY8TrngOyxSHoCU5shy86iA9SRMRrPSyBhEaZRAk6dnbdpmUTez7gtdVo0BCvh9nzQtUycKWSS7PnFQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/subscribable": "5.5.1",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-5.5.1.tgz",
+      "integrity": "sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/subscribable": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-5.5.1.tgz",
+      "integrity": "sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-5.5.1.tgz",
+      "integrity": "sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "undici-types": "^7.19.2"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-5.5.1.tgz",
+      "integrity": "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-5.5.1.tgz",
+      "integrity": "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/offchain-messages": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/subscribable": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-5.5.1.tgz",
+      "integrity": "sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-5.5.1.tgz",
+      "integrity": "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/accounts": "5.5.1",
+        "@solana/codecs": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-5.5.1.tgz",
+      "integrity": "sha512-j4mKlYPHEyu+OD7MBt3jRoX4ScFgkhZC6H65on4Fux6LMScgivPJlwnKoZMnsgxFgWds0pl+BYzSiALDsXlYtw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc": "5.5.1",
+        "@solana/rpc-subscriptions": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-5.5.1.tgz",
+      "integrity": "sha512-aXyhMCEaAp3M/4fP0akwBBQkFPr4pfwoC5CLDq999r/FUwDax2RE/h4Ic7h2Xk+JdcUwsb+rLq85Y52hq84XvQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-5.5.1.tgz",
+      "integrity": "sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@x402/core": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.7.0.tgz",
+      "integrity": "sha512-2l1QaRO50qtWpnTJed45HtGRAUp3z2Mep1caNCuaNBzeiE8OfWfuXmip+ujgp3vWZHxRqag221aRSnKbA6gDaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@x402/evm": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@x402/evm/-/evm-2.7.0.tgz",
+      "integrity": "sha512-085gqcu1ljaomMaitGx2KeQmHVe6ZyaFTT1UFZjhmHdBlNe+jNb+Moa4O1JTMyVNbbNCAZ2M1Do+LqVnAK4OIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@x402/core": "~2.7.0",
+        "viem": "^2.39.3",
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@x402/fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@x402/fetch/-/fetch-2.7.0.tgz",
+      "integrity": "sha512-hkJvoVtYjybkhLk1K2kRB0aVVWaxz43qYBSGZo0wgnUuIUXzmArGohhM/VfG8kVqcl+NDIuCD8tFiKSONr9X6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@x402/core": "~2.7.0",
+        "viem": "^2.39.3",
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@x402/svm": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@x402/svm/-/svm-2.8.0.tgz",
+      "integrity": "sha512-kDkFU9pYR+/j3JUoK9OyaRD6jGF9FtbRMHoGD122J9bwTfkaWc9+f4QVnVBASK6+5DBz7X8bC0/bLrGhMpXiSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana-program/compute-budget": "^0.11.0",
+        "@solana-program/token": "^0.9.0",
+        "@solana-program/token-2022": "^0.6.1",
+        "@x402/core": "~2.8.0"
+      },
+      "peerDependencies": {
+        "@solana/kit": ">=5.1.0"
+      }
+    },
+    "node_modules/@x402/svm/node_modules/@x402/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-ppsvSzyWzlqG+26dcNzOXo/YLaHreWc3lmdv9W81mEhLDWMdPpiGyRjSUyO9BQFuQJMQppvqA7ujUbLE/EaDkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/ox": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.5.tgz",
+      "integrity": "sha512-HgmHmBveYO40H/R3K6TMrwYtHsx/u6TAB+GpZlgJCoW0Sq5Ttpjih0IZZiwGQw7T6vdW4IAyobYrE2mdAvyF8Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.7.tgz",
+      "integrity": "sha512-XA+gOBkzYD3C74sZowtCLTpgtaCdqZhqCvR6y9LXvrKTt/IVU6bz49T4D+BPi475scshCCkb0IklJRw6T1ZlgQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/viem": {
+      "version": "2.47.5",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.5.tgz",
+      "integrity": "sha512-nVrJEQ8GL4JoVIrMBF3wwpTUZun0cpojfnOZ+96GtDWhqxZkVdy6vOEgu+jwfXqfTA/+wrR+YsN9TBQmhDUk0g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.5",
+        "ws": "8.18.3"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -40,8 +40,9 @@
   "homepage": "https://github.com/zeriontech/zerion-ai#readme",
   "license": "MIT",
   "dependencies": {
-    "@x402/fetch": "^2.6.0",
     "@x402/evm": "^2.6.0",
+    "@x402/fetch": "^2.6.0",
+    "@x402/svm": "^2.8.0",
     "viem": "^2.0.0"
   }
 }

--- a/skills/zerion-cli/SKILL.md
+++ b/skills/zerion-cli/SKILL.md
@@ -50,15 +50,24 @@ Get yours at [dashboard.zerion.io](https://dashboard.zerion.io).
 
 ### Option B: x402 pay-per-call (no signup)
 
-No API key needed. Pay $0.01 USDC per request via the [x402 protocol](https://www.x402.org/). Supports EVM (Base) and Solana — auto-detected from key format.
+No API key needed. Pay $0.01 USDC per request via the [x402 protocol](https://www.x402.org/). Supports EVM (Base) and Solana.
+
+**Single key** — format is auto-detected:
 
 ```bash
-# EVM (Base) — 0x-prefixed hex private key
-export WALLET_PRIVATE_KEY="0x..."
+export WALLET_PRIVATE_KEY="0x..."    # EVM (Base) — 0x-prefixed hex
+export WALLET_PRIVATE_KEY="5C1y..."  # Solana — base58 encoded keypair
+```
 
-# Solana — base58 encoded keypair
-export WALLET_PRIVATE_KEY="5C1y..."
+**Both chains simultaneously:**
 
+```bash
+export EVM_PRIVATE_KEY="0x..."
+export SOLANA_PRIVATE_KEY="5C1y..."
+export ZERION_X402_PREFER_SOLANA=true  # optional: prefer Solana when both are set
+```
+
+```bash
 # Per-command flag
 zerion-cli wallet analyze <address> --x402
 
@@ -66,15 +75,16 @@ zerion-cli wallet analyze <address> --x402
 export ZERION_X402=true
 ```
 
-The agent's wallet handles payment automatically using `WALLET_PRIVATE_KEY`.
-
 ## Environment variables
 
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `ZERION_API_KEY` | Yes (unless x402) | API key from dashboard.zerion.io |
-| `WALLET_PRIVATE_KEY` | Yes (for x402) | Private key for x402 payments (0x-hex for EVM/Base, base58 for Solana) |
+| `WALLET_PRIVATE_KEY` | Yes (for x402, single key) | Auto-detected: 0x-hex for EVM/Base, base58 for Solana |
+| `EVM_PRIVATE_KEY` | No | EVM private key for x402; overrides `WALLET_PRIVATE_KEY` for EVM |
+| `SOLANA_PRIVATE_KEY` | No | Solana base58 keypair for x402; overrides `WALLET_PRIVATE_KEY` for Solana |
 | `ZERION_X402` | No | Set to `true` to enable x402 pay-per-call globally |
+| `ZERION_X402_PREFER_SOLANA` | No | Set to `true` to prefer Solana when both keys are configured |
 | `ZERION_API_BASE` | No | Override API base URL (default: `https://api.zerion.io/v1`) |
 
 ## CLI help

--- a/skills/zerion-cli/SKILL.md
+++ b/skills/zerion-cli/SKILL.md
@@ -65,9 +65,7 @@ export WALLET_PRIVATE_KEY="5C1y..."  # Solana — base58 encoded keypair
 export EVM_PRIVATE_KEY="0x..."
 export SOLANA_PRIVATE_KEY="5C1y..."
 export ZERION_X402_PREFER_SOLANA=true  # optional: prefer Solana when both are set
-```
 
-```bash
 # Per-command flag
 zerion-cli wallet analyze <address> --x402
 

--- a/skills/zerion-cli/SKILL.md
+++ b/skills/zerion-cli/SKILL.md
@@ -50,11 +50,14 @@ Get yours at [dashboard.zerion.io](https://dashboard.zerion.io).
 
 ### Option B: x402 pay-per-call (no signup)
 
-No API key needed. Pay $0.01 USDC per request on Base via the [x402 protocol](https://www.x402.org/).
+No API key needed. Pay $0.01 USDC per request via the [x402 protocol](https://www.x402.org/). Supports EVM (Base) and Solana — auto-detected from key format.
 
 ```bash
-# Required for x402 payments
+# EVM (Base) — 0x-prefixed hex private key
 export WALLET_PRIVATE_KEY="0x..."
+
+# Solana — base58 encoded keypair
+export WALLET_PRIVATE_KEY="5C1y..."
 
 # Per-command flag
 zerion-cli wallet analyze <address> --x402
@@ -70,7 +73,7 @@ The agent's wallet handles payment automatically using `WALLET_PRIVATE_KEY`.
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `ZERION_API_KEY` | Yes (unless x402) | API key from dashboard.zerion.io |
-| `WALLET_PRIVATE_KEY` | Yes (for x402) | EVM private key for the wallet paying x402 requests on Base |
+| `WALLET_PRIVATE_KEY` | Yes (for x402) | Private key for x402 payments (0x-hex for EVM/Base, base58 for Solana) |
 | `ZERION_X402` | No | Set to `true` to enable x402 pay-per-call globally |
 | `ZERION_API_BASE` | No | Override API base URL (default: `https://api.zerion.io/v1`) |
 


### PR DESCRIPTION
## Summary
- Auto-detect `WALLET_PRIVATE_KEY` format: `0x`-prefixed hex → EVM (Base), base58 → Solana
- Add `@x402/svm` dependency and register `registerExactSvmScheme` for Solana keys
- Add retry logic (up to 2 retries) to handle Solana facilitator fee-payer rotation
- Update all docs (README, mcp/README, docs/x402-endpoints, skills/zerion-cli) to reflect dual-chain support

## Test plan
- [x] All 126 unit + skills tests pass
- [x] Live Solana x402 payment verified (wallet `dyyxEBLQDFQCeh3BU47Vpuf3x7ySJngSvS3gKcjkZwF`, 3.73 USDC balance)
- [x] Tested `wallet portfolio`, `chains list`, `wallet analyze` commands with `--x402`
- [x] Retry logic handles transient fee-payer rotation failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)