### PR TITLE
fix: rename npm package to zerion-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zerion",
+  "name": "zerion-cli",
   "version": "0.4.0",
   "description": "Zerion for AI agents and developers: hosted MCP docs, wallet-analysis skill, and a JSON-first CLI.",
   "author": "Zerion",


### PR DESCRIPTION
## Summary
- Rename npm package from `zerion` to `zerion-cli` — the `zerion` name on npm is owned by an unrelated SDK
- Previous releases already published as `zerion-cli`, this aligns the source

## Test plan
- [ ] `npm view zerion-cli` shows correct package
- [ ] Release-please picks up new name on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)