### PR TITLE
fix: add npm install to release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,6 +35,8 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org
 
+      - run: npm install
+
       - run: npm test
 
       - run: npm publish --provenance


### PR DESCRIPTION
## Summary
- Add missing `npm install` step before `npm test` in the publish job
- This is why 0.4.0 and 0.4.1 never published — CI had no `node_modules`, so tests failed with `ERR_MODULE_NOT_FOUND` for `viem`

## Test plan
- [ ] Merge → release-please opens release PR → merge that → publish job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)