### PR TITLE
feat(cli): zerion setup skills/mcp + handoff doc

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -132,6 +132,22 @@ zerion config set slippage <percent>     Set slippage tolerance (default: 2%)
 zerion config unset <key>                Remove a config value
 ```
 
+### Manual operations — agent skills & MCP setup
+
+Convenience wrappers for installing Zerion as agent skills (Claude Code, Codex, Cursor, Gemini CLI, OpenCode, …) or wiring the hosted MCP into a coding agent's config.
+
+```
+zerion setup skills                                  Install Zerion skills via `npx skills add` (interactive)
+zerion setup skills --agent claude-code -y           Non-interactive install into Claude Code
+zerion setup skills -g                               Install globally (cross-project)
+zerion setup mcp --print                             Print the canonical Zerion MCP config fragment
+zerion setup mcp --agent cursor                      Merge Zerion server into project .cursor/mcp.json
+zerion setup mcp --agent claude-code -g              Merge into ~/.claude/settings.json (global)
+zerion setup mcp --agent claude-desktop -g           Merge into Claude Desktop's app config
+```
+
+`setup skills` delegates to [vercel-labs/skills](https://github.com/vercel-labs/skills) and installs from [`zeriontech/zerion-agent`](https://github.com/zeriontech/zerion-agent). For the full plugin (skills + slash commands + MCP) inside Claude Code, use `/plugin install zerion-agent@zerion` instead.
+
 ### Other
 
 ```

--- a/cli/commands/setup.js
+++ b/cli/commands/setup.js
@@ -1,0 +1,169 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import { print, printError } from "../lib/util/output.js";
+
+const ZERION_AGENT_REPO = "zeriontech/zerion-agent";
+
+const ZERION_MCP_SERVER = {
+  type: "sse",
+  url: "https://developers.zerion.io/mcp",
+  headers: { Authorization: "Bearer ${ZERION_API_KEY}" },
+};
+
+const HELP = {
+  usage: "zerion setup <skills|mcp> [options]",
+  subcommands: {
+    "setup skills":
+      "Install Zerion agent skills via `npx skills add` (delegates to vercel-labs/skills, supports 45+ agents).",
+    "setup mcp":
+      "Write the Zerion hosted-MCP config fragment into a detected agent's config file.",
+  },
+  flags: {
+    "--global, -g": "Install globally instead of project scope",
+    "--agent <name>": "Target a specific agent (e.g. claude-code, cursor, claude-desktop)",
+    "--print": "Print the MCP config fragment to stdout instead of writing (mcp only)",
+    "--dry-run": "Print the underlying command/target without executing",
+    "--yes, -y": "Skip prompts (skills only — passes through to npx skills)",
+  },
+  examples: {
+    "zerion setup skills": "Interactive install across detected agents",
+    "zerion setup skills --agent claude-code -y": "Non-interactive install into Claude Code",
+    "zerion setup skills -g": "Install globally",
+    "zerion setup mcp --print": "View the canonical Zerion MCP fragment",
+    "zerion setup mcp --agent cursor": "Merge Zerion MCP into project .cursor/mcp.json",
+    "zerion setup mcp --agent claude-desktop -g": "Merge into Claude Desktop's global config",
+  },
+  source: `https://github.com/${ZERION_AGENT_REPO}`,
+};
+
+const MCP_TARGETS = {
+  cursor: {
+    global: () => join(homedir(), ".cursor", "mcp.json"),
+    project: () => join(process.cwd(), ".cursor", "mcp.json"),
+  },
+  "claude-code": {
+    global: () => join(homedir(), ".claude", "settings.json"),
+    project: () => join(process.cwd(), ".claude", "settings.json"),
+  },
+  "claude-desktop": {
+    global: () => {
+      if (process.platform === "darwin") {
+        return join(
+          homedir(),
+          "Library",
+          "Application Support",
+          "Claude",
+          "claude_desktop_config.json"
+        );
+      }
+      if (process.platform === "win32") {
+        return join(homedir(), "AppData", "Roaming", "Claude", "claude_desktop_config.json");
+      }
+      return join(homedir(), ".config", "Claude", "claude_desktop_config.json");
+    },
+  },
+};
+
+export default async function setup(args, flags) {
+  const [subcommand, ...rest] = args;
+
+  if (flags.help || flags.h || !subcommand) {
+    print(HELP);
+    return;
+  }
+
+  switch (subcommand) {
+    case "skills":
+      return setupSkills(rest, flags);
+    case "mcp":
+      return setupMcp(rest, flags);
+    default:
+      printError(
+        "unknown_subcommand",
+        `Unknown setup subcommand: ${subcommand}`,
+        { suggestion: "Run 'zerion setup --help' for usage", subcommand }
+      );
+      process.exit(1);
+  }
+}
+
+function setupSkills(_args, flags) {
+  const npxArgs = ["-y", "skills", "add", ZERION_AGENT_REPO];
+  if (flags.global || flags.g) npxArgs.push("-g");
+  if (flags.agent) npxArgs.push("-a", flags.agent);
+  if (flags.yes || flags.y) npxArgs.push("--yes");
+
+  const renderedCommand = `npx ${npxArgs.join(" ")}`;
+
+  if (flags["dry-run"]) {
+    print({ ok: true, dryRun: true, command: renderedCommand, source: ZERION_AGENT_REPO });
+    return;
+  }
+
+  const res = spawnSync("npx", npxArgs, { stdio: "inherit" });
+  if (res.status !== 0) {
+    printError("skills_install_failed", "npx skills add returned non-zero", {
+      exitCode: res.status,
+      command: renderedCommand,
+    });
+    process.exit(res.status ?? 1);
+  }
+  print({ ok: true, action: "setup-skills", source: ZERION_AGENT_REPO });
+}
+
+function setupMcp(_args, flags) {
+  if (flags.print) {
+    const fragment = { mcpServers: { zerion: ZERION_MCP_SERVER } };
+    process.stdout.write(JSON.stringify(fragment, null, 2) + "\n");
+    return;
+  }
+
+  const agent = flags.agent;
+  if (!agent) {
+    printError(
+      "missing_agent",
+      "Specify --agent <name> (cursor, claude-code, claude-desktop) or use --print to view the fragment.",
+      { supportedAgents: Object.keys(MCP_TARGETS) }
+    );
+    process.exit(1);
+  }
+
+  const target = MCP_TARGETS[agent];
+  if (!target) {
+    printError("unknown_agent", `Unknown agent: ${agent}`, {
+      supportedAgents: Object.keys(MCP_TARGETS),
+    });
+    process.exit(1);
+  }
+
+  const wantGlobal = flags.global || flags.g;
+  const scope = wantGlobal || !target.project ? "global" : "project";
+  const path = target[scope]();
+
+  if (flags["dry-run"]) {
+    print({ ok: true, dryRun: true, agent, scope, target: path });
+    return;
+  }
+
+  let config = {};
+  if (existsSync(path)) {
+    try {
+      config = JSON.parse(readFileSync(path, "utf8"));
+    } catch (err) {
+      printError("invalid_config", `Existing config at ${path} is not valid JSON`, {
+        error: err.message,
+      });
+      process.exit(1);
+    }
+  } else {
+    mkdirSync(dirname(path), { recursive: true });
+  }
+
+  config.mcpServers = config.mcpServers || {};
+  config.mcpServers.zerion = ZERION_MCP_SERVER;
+  writeFileSync(path, JSON.stringify(config, null, 2) + "\n");
+
+  print({ ok: true, action: "setup-mcp", agent, scope, target: path });
+}

--- a/cli/router.js
+++ b/cli/router.js
@@ -121,6 +121,11 @@ function printUsage() {
       "defaultChain": "Default chain (default: ethereum)",
       "slippage": "Default slippage % for swaps (default: 2)",
     },
+    setup: {
+      "setup skills": "Install Zerion agent skills via `npx skills add zeriontech/zerion-agent` (45+ hosts)",
+      "setup mcp --agent <name>": "Write the Zerion hosted-MCP fragment into a detected agent's config (cursor, claude-code, claude-desktop)",
+      "setup mcp --print": "Print the canonical MCP fragment to stdout",
+    },
     chains: [
       "ethereum", "base", "arbitrum", "optimism", "polygon",
       "binance-smart-chain", "avalanche", "gnosis", "scroll",

--- a/cli/zerion.js
+++ b/cli/zerion.js
@@ -92,6 +92,11 @@ register("agent", "delete-policy", agentDeletePolicy);
 import configCmd from "./commands/config.js";
 registerSingle("config", configCmd);
 
+// --- Setup (skills + mcp installer wrappers) ---
+
+import setupCmd from "./commands/setup.js";
+registerSingle("setup", setupCmd);
+
 // --- Dispatch ---
 
 try {

--- a/docs/superpowers/handoff-2026-04-26.md
+++ b/docs/superpowers/handoff-2026-04-26.md
@@ -1,0 +1,114 @@
+# Handoff — zerion-agent split, 2026-04-26 evening
+
+Spec: `docs/superpowers/specs/2026-04-26-zerion-agent-split-design.md`
+Plan: `docs/superpowers/plans/2026-04-26-zerion-agent-split.md`
+
+## What landed tonight
+
+### `zeriontech/zerion-agent` (new private repo)
+
+- Created private under `zeriontech` org
+- Content migrated: 4 skills, 8 MCP tool catalog files, 5 example dirs, demo SVG, root `.mcp.json`
+- Claude Code plugin manifests authored (`.claude-plugin/plugin.json` + `marketplace.json`) — marketplace name is `zerion`, install command will be `/plugin install zerion-agent@zerion`
+- README rewritten for agent-integration audience, three install paths documented
+- release-please + lint workflows in CI
+- **v0.2.0 released** (release-please bumped 0.1.0 → 0.2.0 to absorb feat commits)
+- SKILL.md homepage URLs updated to `https://github.com/zeriontech/zerion-cli` (will resolve once rename happens)
+
+### `zeriontech/zerion-ai` (still named zerion-ai)
+
+- PR #19 merged (`chore: split agent assets into zeriontech/zerion-agent`)
+- Removed: `skills/`, `mcp/`, `examples/`, `assets/`, root `.mcp.json`
+- Removed: 4 unit tests that read those dirs (`skills.test.mjs`, `examples.test.mjs`, `mcp-tools.test.mjs`, `consistency.test.mjs`) — content lives with content in zerion-agent
+- README rewritten for CLI-only audience, links out to zerion-agent
+- Pre-existing `package-lock.json` issue from `chore: clear npm audit` commit fixed in the same PR
+- All 92 unit tests pass
+- CHANGELOG untouched — release-please will pick up the chore commit
+
+### Verified
+
+- `npx skills add /Users/graysonho/Documents/GitHub/zerion-agent` discovers + installs all 4 skills into `.claude/skills/` (test run in `/tmp`, cleaned up)
+- Plugin manifests passed `plugin-dev:plugin-validator` review
+
+## What's blocked, needs Grayson
+
+### 1. Rename `zerion-ai` → `zerion-cli` on GitHub
+
+**Why blocked:** the `graysonhyc` GitHub account does not have admin permission on `zeriontech/zerion-ai`. API call returned `permissions.admin: False`. `gh repo rename` returned 404 (gh treats permission denial as 404).
+
+**Action:** rename via the web UI at <https://github.com/zeriontech/zerion-ai/settings> → "Repository name" field, change to `zerion-cli`, click "Rename". Or grant admin to graysonhyc and run:
+
+```bash
+gh repo rename zerion-cli --repo zeriontech/zerion-ai --yes
+```
+
+**After rename:**
+
+```bash
+cd /Users/graysonho/Documents/GitHub/zerion-ai
+git remote set-url origin https://github.com/zeriontech/zerion-cli.git
+git remote -v   # confirm
+# Optional: rename the local dir
+cd /Users/graysonho/Documents/GitHub
+mv zerion-ai zerion-cli
+```
+
+### 2. Update `zerion-cli` `package.json` URLs (after rename)
+
+Open a small PR:
+
+```bash
+cd /Users/graysonho/Documents/GitHub/zerion-cli   # or zerion-ai if not renamed locally
+git checkout -b chore/update-repo-urls
+```
+
+Edit `package.json` — change three URLs:
+
+- `repository.url`: `git+https://github.com/zeriontech/zerion-ai.git` → `git+https://github.com/zeriontech/zerion-cli.git`
+- `bugs.url`: `https://github.com/zeriontech/zerion-ai/issues` → `https://github.com/zeriontech/zerion-cli/issues`
+- `homepage`: `https://github.com/zeriontech/zerion-ai#readme` → `https://github.com/zeriontech/zerion-cli#readme`
+
+Commit with `chore: update package.json URLs to zerion-cli` and PR. After merge, the next release-please run pushes a new npm version that has the corrected URLs in package metadata (`npm view zerion-cli repository`).
+
+### 3. Flip `zerion-agent` to public when ready
+
+```bash
+gh repo edit zeriontech/zerion-agent --visibility public --accept-visibility-change-consequences
+```
+
+Tonight it stays private (your call). After flip:
+
+- `npx skills add zeriontech/zerion-agent` works without GitHub auth
+- `/plugin marketplace add zeriontech/zerion-agent` works for any user
+- External announcement (release notes link, dev-rel, partner heads-up) becomes appropriate
+
+## Status of Plan chunks
+
+| Chunk | Status |
+|-------|--------|
+| 1: Scaffold zerion-agent | ✅ Done |
+| 2: Migrate skills | ✅ Done |
+| 3: Migrate mcp/examples/assets | ✅ Done |
+| 4: Author plugin manifests | ✅ Done (validator approved) |
+| 5: README + release tooling + CI | ✅ Done |
+| 6: Push + verify install paths | ✅ Done (npx skills verified locally) |
+| 7: Clean up zerion-ai + rename | 🟡 Cleanup merged; rename pending admin |
+| 8: Cross-link READMEs + memory | ✅ Done |
+| 9: `zerion setup skills/mcp` | ⏳ TBD this session |
+
+## Useful commands
+
+Quick install verification once rename + flip-to-public are done:
+
+```bash
+mkdir /tmp/install-test && cd /tmp/install-test
+npx -y skills add zeriontech/zerion-agent --yes --agent claude-code
+find . -name SKILL.md   # expect 4 files under .claude/skills/
+```
+
+Local tail of recent CLI activity:
+
+```bash
+git -C /Users/graysonho/Documents/GitHub/zerion-ai log --oneline -10
+git -C /Users/graysonho/Documents/GitHub/zerion-agent log --oneline -10
+```

--- a/docs/superpowers/handoff-2026-04-26.md
+++ b/docs/superpowers/handoff-2026-04-26.md
@@ -25,6 +25,15 @@ Plan: `docs/superpowers/plans/2026-04-26-zerion-agent-split.md`
 - All 92 unit tests pass
 - CHANGELOG untouched — release-please will pick up the chore commit
 
+### `zerion setup skills` / `zerion setup mcp` (Chunk 9)
+
+Implemented in `cli/commands/setup.js`. Sits on PR branch `chore/handoff-doc` (open as PR #20 when convenient). Behavior:
+
+- `zerion setup skills` shells out to `npx -y skills add zeriontech/zerion-agent`, supports `--agent <name>`, `-g`, `-y` passthrough, and `--dry-run` for inspection.
+- `zerion setup mcp --print` emits the canonical hosted-MCP config fragment.
+- `zerion setup mcp --agent <cursor|claude-code|claude-desktop>` merges the Zerion server into the agent's config file (project scope by default, `-g` for global). Preserves any existing `mcpServers` entries.
+- 12 new tests in `tests/unit/cli/commands/setup.test.mjs`; full suite at 122 tests, 0 fails.
+
 ### Verified
 
 - `npx skills add /Users/graysonho/Documents/GitHub/zerion-agent` discovers + installs all 4 skills into `.claude/skills/` (test run in `/tmp`, cleaned up)
@@ -94,7 +103,7 @@ Tonight it stays private (your call). After flip:
 | 6: Push + verify install paths | ✅ Done (npx skills verified locally) |
 | 7: Clean up zerion-ai + rename | 🟡 Cleanup merged; rename pending admin |
 | 8: Cross-link READMEs + memory | ✅ Done |
-| 9: `zerion setup skills/mcp` | ⏳ TBD this session |
+| 9: `zerion setup skills/mcp` | ✅ Done — implemented + 12 tests pass; ships in next CLI release |
 
 ## Useful commands
 

--- a/tests/unit/cli/commands/setup.test.mjs
+++ b/tests/unit/cli/commands/setup.test.mjs
@@ -1,0 +1,143 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ZERION_BIN = fileURLToPath(new URL("../../../../cli/zerion.js", import.meta.url));
+
+function runZerion(args, opts = {}) {
+  return spawnSync("node", [ZERION_BIN, ...args], {
+    encoding: "utf8",
+    env: process.env,
+    ...opts,
+  });
+}
+
+describe("zerion setup", () => {
+  it("setup with no args prints usage including skills + mcp", () => {
+    const res = runZerion(["setup"]);
+    assert.equal(res.status, 0);
+    const out = JSON.parse(res.stdout);
+    assert.match(out.usage, /setup/);
+    assert.ok(out.subcommands["setup skills"]);
+    assert.ok(out.subcommands["setup mcp"]);
+  });
+
+  it("unknown subcommand fails with structured error", () => {
+    const res = runZerion(["setup", "bogus"]);
+    assert.notEqual(res.status, 0);
+    const err = JSON.parse(res.stderr);
+    assert.equal(err.error.code, "unknown_subcommand");
+    assert.equal(err.error.subcommand, "bogus");
+  });
+
+  describe("setup skills", () => {
+    it("--dry-run prints the npx command without executing", () => {
+      const res = runZerion(["setup", "skills", "--dry-run"]);
+      assert.equal(res.status, 0);
+      const out = JSON.parse(res.stdout);
+      assert.equal(out.dryRun, true);
+      assert.match(out.command, /npx -y skills add zeriontech\/zerion-agent/);
+      assert.equal(out.source, "zeriontech/zerion-agent");
+    });
+
+    it("--global passes -g to npx skills", () => {
+      const res = runZerion(["setup", "skills", "--dry-run", "--global"]);
+      const out = JSON.parse(res.stdout);
+      assert.match(out.command, /\s-g(\s|$)/);
+    });
+
+    it("--agent passes -a <name> to npx skills", () => {
+      const res = runZerion(["setup", "skills", "--dry-run", "--agent", "claude-code"]);
+      const out = JSON.parse(res.stdout);
+      assert.match(out.command, /-a claude-code/);
+    });
+
+    it("--yes passes --yes to npx skills", () => {
+      const res = runZerion(["setup", "skills", "--dry-run", "--yes"]);
+      const out = JSON.parse(res.stdout);
+      assert.match(out.command, /--yes/);
+    });
+  });
+
+  describe("setup mcp", () => {
+    it("--print emits the canonical MCP fragment as JSON", () => {
+      const res = runZerion(["setup", "mcp", "--print"]);
+      assert.equal(res.status, 0);
+      const data = JSON.parse(res.stdout);
+      assert.ok(data.mcpServers?.zerion);
+      assert.equal(data.mcpServers.zerion.url, "https://developers.zerion.io/mcp");
+      assert.equal(data.mcpServers.zerion.type, "sse");
+      assert.match(data.mcpServers.zerion.headers.Authorization, /\$\{ZERION_API_KEY\}/);
+    });
+
+    it("missing --agent fails with structured error", () => {
+      const res = runZerion(["setup", "mcp"]);
+      assert.notEqual(res.status, 0);
+      const err = JSON.parse(res.stderr);
+      assert.equal(err.error.code, "missing_agent");
+      assert.deepEqual(err.error.supportedAgents, ["cursor", "claude-code", "claude-desktop"]);
+    });
+
+    it("unknown agent fails with structured error", () => {
+      const res = runZerion(["setup", "mcp", "--agent", "bogus"]);
+      assert.notEqual(res.status, 0);
+      const err = JSON.parse(res.stderr);
+      assert.equal(err.error.code, "unknown_agent");
+    });
+
+    it("--dry-run reports the target path without writing", () => {
+      const res = runZerion(["setup", "mcp", "--agent", "cursor", "--dry-run"]);
+      assert.equal(res.status, 0);
+      const out = JSON.parse(res.stdout);
+      assert.equal(out.dryRun, true);
+      assert.equal(out.agent, "cursor");
+      assert.match(out.target, /\.cursor\/mcp\.json$/);
+    });
+
+    it("writes Zerion server into a brand-new project cursor config", () => {
+      const dir = realpathSync(mkdtempSync(join(tmpdir(), "zerion-setup-")));
+      try {
+        const res = runZerion(["setup", "mcp", "--agent", "cursor"], { cwd: dir });
+        assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+        const out = JSON.parse(res.stdout);
+        assert.equal(out.ok, true);
+        assert.equal(out.target, join(dir, ".cursor", "mcp.json"));
+
+        const written = JSON.parse(readFileSync(out.target, "utf8"));
+        assert.equal(written.mcpServers.zerion.url, "https://developers.zerion.io/mcp");
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("preserves existing mcpServers entries when merging", () => {
+      const dir = realpathSync(mkdtempSync(join(tmpdir(), "zerion-setup-")));
+      try {
+        const targetDir = join(dir, ".cursor");
+        const target = join(targetDir, "mcp.json");
+        mkdirSync(targetDir, { recursive: true });
+        writeFileSync(
+          target,
+          JSON.stringify({
+            mcpServers: {
+              "other-server": { command: "/usr/local/bin/other" },
+            },
+          })
+        );
+
+        const res = runZerion(["setup", "mcp", "--agent", "cursor"], { cwd: dir });
+        assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+
+        const written = JSON.parse(readFileSync(target, "utf8"));
+        assert.ok(written.mcpServers["other-server"], "previous server preserved");
+        assert.ok(written.mcpServers.zerion, "zerion server added");
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Two pieces from Chunk 9 of the zerion-agent split plan:

1. **`zerion setup skills` / `zerion setup mcp`** — Firecrawl-style convenience wrappers in the CLI. `setup skills` delegates to `npx -y skills add zeriontech/zerion-agent`. `setup mcp` writes the canonical Zerion hosted-MCP fragment into a detected agent's config (cursor, claude-code, claude-desktop) or prints it with `--print`.
2. **Handoff doc** — `docs/superpowers/handoff-2026-04-26.md` documenting status of the split, what's done, and the remaining manual steps that require admin perms (rename `zerion-ai` → `zerion-cli`).

## Why now

The split landed in #19 tonight. This PR adds the third install path documented in the README (alongside `npx skills add` and `/plugin install`) and records the manual rename steps so anyone with admin can pick up tomorrow.

## Test plan

- [x] `node --test tests/unit/cli/commands/setup.test.mjs` — 12/12 pass
- [x] Full unit suite — 122/122 pass (104 active, 18 pre-existing skips)
- [x] Manual: `zerion setup` prints usage; `zerion setup mcp --print` emits valid JSON; `zerion setup skills --dry-run` shows command without running
- [x] Manual: `zerion setup mcp --agent cursor` writes/merges into `.cursor/mcp.json` correctly (verified via tmp dir test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)