### PR TITLE
chore: remove `zerion setup mcp` command and MCP references

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npx -y zerion-cli init -y --browser
 
 Requires Node.js 20 or later.
 
-### Setup Skills and MCP
+### Setup Skills
 
 If you are using an AI coding agent (Claude Code, Cursor, Windsurf, Claude Desktop, etc.), you can also install the skills individually with:
 
@@ -32,12 +32,6 @@ zerion setup skills
 ```
 
 This installs skills globally across all detected coding agents by default. Use `--agent <name>` to scope it to one agent, or `-g` to force a global install.
-
-To install the Zerion hosted MCP server (live Zerion API docs as a tool inside your editor):
-
-```bash
-zerion setup mcp --agent <claude-code|cursor|claude-desktop>
-```
 
 ### Agent skills
 
@@ -65,7 +59,7 @@ Zerion CLI splits into two surfaces, by design.
 - **Wallet management and agent token setup are manual.** `wallet create`, `import`, `backup`, and `delete` all prompt for a passphrase. `wallet sync` emits a QR code you scan with the Zerion app. `agent create-token` mints a scoped trading credential bound to a specific wallet, and `agent create-policy` attaches the rules it has to obey — allowed chains, expiry, transfer/approval gates, contract allowlists. The sibling admin commands (`agent list-tokens`, `use-token`, `revoke-token`, `list-policies`, `show-policy`, `delete-policy`) are also gestures you make yourself. No key material moves and no spending credential widens without you in the loop.
 - **Analysis, signing, trading, and discovery are for agents.** `analyze`, `portfolio`, `positions`, `history`, `pnl`, `sign-message`, `sign-typed-data`, `swap`, `bridge`, `send`, `swap tokens`, `search`, `chains`, `wallet list`, `wallet fund`, and `watch list` emit JSON to stdout, structured errors to stderr, and skip confirmation dialogs. Once an agent token is configured, signing and trading fire immediately — the token authorizes operations on behalf of the wallet without a passphrase prompt.
 
-Setup gestures (`init`, `setup skills`, `setup mcp`, `config set/unset/list`, `watch` add/remove) are one-time configuration steps you run yourself before automation takes over.
+Setup gestures (`init`, `setup skills`, `config set/unset/list`, `watch` add/remove) are one-time configuration steps you run yourself before automation takes over.
 
 The split is the point. You stage by hand once — create or import a wallet, set a passphrase, mint an agent token, attach a policy — then hand the agent token to an automation that can only do what the policy allows. Treat agent tokens like API keys with spending power; use [agent policies](#agent-policies) to scope them down to specific chains, addresses, or expiry windows.
 
@@ -236,8 +230,6 @@ Track wallets by name without exposing addresses in commands.
 | `zerion init -y --browser` | Non-interactive init that opens dashboard.zerion.io for the API key | `npx -y zerion-cli init -y --browser` |
 | `zerion setup skills` | Install Zerion agent skills into detected coding agents | `zerion setup skills` |
 | `zerion setup skills --agent claude-code` | Install into a specific agent | `zerion setup skills --agent claude-code` |
-| `zerion setup mcp --agent <name>` | Merge the Zerion hosted-MCP fragment into an agent's config | `zerion setup mcp --agent cursor` |
-| `zerion setup mcp --print` | Print the canonical MCP fragment without writing | `zerion setup mcp --print` |
 
 ### Configuration
 
@@ -347,7 +339,7 @@ To force a specific version, add `Release-As: 2.0.0` in a commit message body.
 
 - **API documentation** — <https://developers.zerion.io/introduction>
 - **Get an API key** — <https://dashboard.zerion.io>
-- **Agent skills + MCP** — <https://github.com/zeriontech/zerion-agent>
+- **Agent skills** — <https://github.com/zeriontech/zerion-agent>
 - **Building with AI** — <https://developers.zerion.io/reference/building-with-ai>
 
 ## License

--- a/commands/init.js
+++ b/commands/init.js
@@ -120,7 +120,6 @@ function printSuccessSummary() {
   log("    → Portfolio         zerion portfolio 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
   log("    → Trade             zerion swap usdc eth 100 --chain ethereum");
   log("");
-  log("  → Add MCP:      zerion setup mcp --agent <claude-code|cursor|claude-desktop>");
   log("  → All commands: zerion --help");
   log("");
   log("  Building agent automation? Use `zerion agent create-token` + `agent create-policy`");

--- a/commands/setup.js
+++ b/commands/setup.js
@@ -1,69 +1,26 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { homedir } from "node:os";
 import { print, printError } from "../utils/common/output.js";
 
 const ZERION_AGENT_REPO = "zeriontech/zerion-agent";
 
-const ZERION_MCP_SERVER = {
-  type: "sse",
-  url: "https://developers.zerion.io/mcp",
-  headers: { Authorization: "Bearer ${ZERION_API_KEY}" },
-};
-
 const HELP = {
-  usage: "zerion setup <skills|mcp> [options]",
+  usage: "zerion setup <skills> [options]",
   subcommands: {
     "setup skills":
       "Install Zerion agent skills via `npx skills add` (delegates to vercel-labs/skills, supports 45+ agents).",
-    "setup mcp":
-      "Write the Zerion hosted-MCP config fragment into a detected agent's config file.",
   },
   flags: {
     "--global, -g": "Install globally instead of project scope",
     "--agent <name>": "Target a specific agent (e.g. claude-code, cursor, claude-desktop)",
-    "--print": "Print the MCP config fragment to stdout instead of writing (mcp only)",
-    "--dry-run": "Print the underlying command/target without executing",
-    "--yes, -y": "Skip prompts (skills only — passes through to npx skills)",
+    "--dry-run": "Print the underlying command without executing",
+    "--yes, -y": "Skip prompts (passes through to npx skills)",
   },
   examples: {
     "zerion setup skills": "Interactive install across detected agents",
     "zerion setup skills --agent claude-code -y": "Non-interactive install into Claude Code",
     "zerion setup skills -g": "Install globally",
-    "zerion setup mcp --print": "View the canonical Zerion MCP fragment",
-    "zerion setup mcp --agent cursor": "Merge Zerion MCP into project .cursor/mcp.json",
-    "zerion setup mcp --agent claude-desktop -g": "Merge into Claude Desktop's global config",
   },
   source: `https://github.com/${ZERION_AGENT_REPO}`,
-};
-
-const MCP_TARGETS = {
-  cursor: {
-    global: () => join(homedir(), ".cursor", "mcp.json"),
-    project: () => join(process.cwd(), ".cursor", "mcp.json"),
-  },
-  "claude-code": {
-    global: () => join(homedir(), ".claude", "settings.json"),
-    project: () => join(process.cwd(), ".claude", "settings.json"),
-  },
-  "claude-desktop": {
-    global: () => {
-      if (process.platform === "darwin") {
-        return join(
-          homedir(),
-          "Library",
-          "Application Support",
-          "Claude",
-          "claude_desktop_config.json"
-        );
-      }
-      if (process.platform === "win32") {
-        return join(homedir(), "AppData", "Roaming", "Claude", "claude_desktop_config.json");
-      }
-      return join(homedir(), ".config", "Claude", "claude_desktop_config.json");
-    },
-  },
 };
 
 export default async function setup(args, flags) {
@@ -77,8 +34,6 @@ export default async function setup(args, flags) {
   switch (subcommand) {
     case "skills":
       return setupSkills(rest, flags);
-    case "mcp":
-      return setupMcp(rest, flags);
     default:
       printError(
         "unknown_subcommand",
@@ -111,59 +66,4 @@ function setupSkills(_args, flags) {
     process.exit(res.status ?? 1);
   }
   print({ ok: true, action: "setup-skills", source: ZERION_AGENT_REPO });
-}
-
-function setupMcp(_args, flags) {
-  if (flags.print) {
-    const fragment = { mcpServers: { zerion: ZERION_MCP_SERVER } };
-    process.stdout.write(JSON.stringify(fragment, null, 2) + "\n");
-    return;
-  }
-
-  const agent = flags.agent;
-  if (!agent) {
-    printError(
-      "missing_agent",
-      "Specify --agent <name> (cursor, claude-code, claude-desktop) or use --print to view the fragment.",
-      { supportedAgents: Object.keys(MCP_TARGETS) }
-    );
-    process.exit(1);
-  }
-
-  const target = MCP_TARGETS[agent];
-  if (!target) {
-    printError("unknown_agent", `Unknown agent: ${agent}`, {
-      supportedAgents: Object.keys(MCP_TARGETS),
-    });
-    process.exit(1);
-  }
-
-  const wantGlobal = flags.global || flags.g;
-  const scope = wantGlobal || !target.project ? "global" : "project";
-  const path = target[scope]();
-
-  if (flags["dry-run"]) {
-    print({ ok: true, dryRun: true, agent, scope, target: path });
-    return;
-  }
-
-  let config = {};
-  if (existsSync(path)) {
-    try {
-      config = JSON.parse(readFileSync(path, "utf8"));
-    } catch (err) {
-      printError("invalid_config", `Existing config at ${path} is not valid JSON`, {
-        error: err.message,
-      });
-      process.exit(1);
-    }
-  } else {
-    mkdirSync(dirname(path), { recursive: true });
-  }
-
-  config.mcpServers = config.mcpServers || {};
-  config.mcpServers.zerion = ZERION_MCP_SERVER;
-  writeFileSync(path, JSON.stringify(config, null, 2) + "\n");
-
-  print({ ok: true, action: "setup-mcp", agent, scope, target: path });
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zerion-cli",
   "version": "1.0.0",
-  "description": "Zerion for AI agents and developers: hosted MCP docs, wallet-analysis skill, and a JSON-first CLI.",
+  "description": "Zerion for AI agents and developers: wallet-analysis skill bundle and a JSON-first CLI.",
   "author": "Zerion",
   "type": "module",
   "bin": {
@@ -34,7 +34,6 @@
   "keywords": [
     "zerion",
     "ai",
-    "mcp",
     "wallet",
     "openclaw",
     "cli"

--- a/router.js
+++ b/router.js
@@ -125,8 +125,6 @@ function printUsage() {
       "init": "One-shot onboarding: install CLI globally, configure API key, install agent skills",
       "init -y --browser": "Non-interactive init that opens dashboard.zerion.io for the API key",
       "setup skills": "Install Zerion agent skills via `npx skills add zeriontech/zerion-agent` (45+ hosts)",
-      "setup mcp --agent <name>": "Write the Zerion hosted-MCP fragment into a detected agent's config (cursor, claude-code, claude-desktop)",
-      "setup mcp --print": "Print the canonical MCP fragment to stdout",
     },
     chains: [
       "ethereum", "base", "arbitrum", "optimism", "polygon",

--- a/tests/unit/cli/commands/setup.test.mjs
+++ b/tests/unit/cli/commands/setup.test.mjs
@@ -1,9 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync, realpathSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ZERION_BIN = fileURLToPath(new URL("../../../../zerion.js", import.meta.url));
@@ -17,13 +14,12 @@ function runZerion(args, opts = {}) {
 }
 
 describe("zerion setup", () => {
-  it("setup with no args prints usage including skills + mcp", () => {
+  it("setup with no args prints usage including skills", () => {
     const res = runZerion(["setup"]);
     assert.equal(res.status, 0);
     const out = JSON.parse(res.stdout);
     assert.match(out.usage, /setup/);
     assert.ok(out.subcommands["setup skills"]);
-    assert.ok(out.subcommands["setup mcp"]);
   });
 
   it("unknown subcommand fails with structured error", () => {
@@ -60,84 +56,6 @@ describe("zerion setup", () => {
       const res = runZerion(["setup", "skills", "--dry-run", "--yes"]);
       const out = JSON.parse(res.stdout);
       assert.match(out.command, /--yes/);
-    });
-  });
-
-  describe("setup mcp", () => {
-    it("--print emits the canonical MCP fragment as JSON", () => {
-      const res = runZerion(["setup", "mcp", "--print"]);
-      assert.equal(res.status, 0);
-      const data = JSON.parse(res.stdout);
-      assert.ok(data.mcpServers?.zerion);
-      assert.equal(data.mcpServers.zerion.url, "https://developers.zerion.io/mcp");
-      assert.equal(data.mcpServers.zerion.type, "sse");
-      assert.match(data.mcpServers.zerion.headers.Authorization, /\$\{ZERION_API_KEY\}/);
-    });
-
-    it("missing --agent fails with structured error", () => {
-      const res = runZerion(["setup", "mcp"]);
-      assert.notEqual(res.status, 0);
-      const err = JSON.parse(res.stderr);
-      assert.equal(err.error.code, "missing_agent");
-      assert.deepEqual(err.error.supportedAgents, ["cursor", "claude-code", "claude-desktop"]);
-    });
-
-    it("unknown agent fails with structured error", () => {
-      const res = runZerion(["setup", "mcp", "--agent", "bogus"]);
-      assert.notEqual(res.status, 0);
-      const err = JSON.parse(res.stderr);
-      assert.equal(err.error.code, "unknown_agent");
-    });
-
-    it("--dry-run reports the target path without writing", () => {
-      const res = runZerion(["setup", "mcp", "--agent", "cursor", "--dry-run"]);
-      assert.equal(res.status, 0);
-      const out = JSON.parse(res.stdout);
-      assert.equal(out.dryRun, true);
-      assert.equal(out.agent, "cursor");
-      assert.match(out.target, /\.cursor\/mcp\.json$/);
-    });
-
-    it("writes Zerion server into a brand-new project cursor config", () => {
-      const dir = realpathSync(mkdtempSync(join(tmpdir(), "zerion-setup-")));
-      try {
-        const res = runZerion(["setup", "mcp", "--agent", "cursor"], { cwd: dir });
-        assert.equal(res.status, 0, `stderr: ${res.stderr}`);
-        const out = JSON.parse(res.stdout);
-        assert.equal(out.ok, true);
-        assert.equal(out.target, join(dir, ".cursor", "mcp.json"));
-
-        const written = JSON.parse(readFileSync(out.target, "utf8"));
-        assert.equal(written.mcpServers.zerion.url, "https://developers.zerion.io/mcp");
-      } finally {
-        rmSync(dir, { recursive: true, force: true });
-      }
-    });
-
-    it("preserves existing mcpServers entries when merging", () => {
-      const dir = realpathSync(mkdtempSync(join(tmpdir(), "zerion-setup-")));
-      try {
-        const targetDir = join(dir, ".cursor");
-        const target = join(targetDir, "mcp.json");
-        mkdirSync(targetDir, { recursive: true });
-        writeFileSync(
-          target,
-          JSON.stringify({
-            mcpServers: {
-              "other-server": { command: "/usr/local/bin/other" },
-            },
-          })
-        );
-
-        const res = runZerion(["setup", "mcp", "--agent", "cursor"], { cwd: dir });
-        assert.equal(res.status, 0, `stderr: ${res.stderr}`);
-
-        const written = JSON.parse(readFileSync(target, "utf8"));
-        assert.ok(written.mcpServers["other-server"], "previous server preserved");
-        assert.ok(written.mcpServers.zerion, "zerion server added");
-      } finally {
-        rmSync(dir, { recursive: true, force: true });
-      }
     });
   });
 });

--- a/zerion.js
+++ b/zerion.js
@@ -92,7 +92,7 @@ register("agent", "delete-policy", agentDeletePolicy);
 import configCmd from "./commands/config.js";
 registerSingle("config", configCmd);
 
-// --- Setup (skills + mcp installer wrappers) ---
+// --- Setup (skills installer wrapper) ---
 
 import setupCmd from "./commands/setup.js";
 registerSingle("setup", setupCmd);


### PR DESCRIPTION
## Summary

- Drop the `zerion setup mcp` subcommand and all MCP wiring from the CLI.
- Strip MCP references from `README.md`, `router.js` help, `commands/init.js` success summary, `package.json` description + keywords, and the comment in `zerion.js`.
- Remove the `setup mcp` describe block from `tests/unit/cli/commands/setup.test.mjs` (skills tests untouched).

## Why

The hosted MCP at `developers.zerion.io/mcp` currently fails OAuth validation in MCP clients — Mintlify publishes its internal preview hostname (`zerion-f99485ad.main.mintlify.me`) in `/.well-known/oauth-protected-resource` instead of the canonical custom domain, and Claude Code's MCP SDK rejects with:

```
SDK auth failed: Protected resource https://zerion-f99485ad.main.mintlify.me/mcp does not match expected https://developers.zerion.io/mcp (or origin)
```

On top of that, the endpoint actually serves the docs-search MCP (2 tools: `search_zerion_api`, `query_docs_filesystem_zerion_api`) rather than the 8-tool wallet/trading MCP that previous README copy advertised. Until both upstream issues are resolved we should not ship a `setup mcp` flow.

Skills + CLI continue to work; this only removes the broken MCP install path.

## Test plan

- [x] `npm test` — 101/101 unit tests pass locally.
- [x] `node ./zerion.js setup` — usage now lists only `setup skills`.
- [x] `node ./zerion.js setup mcp` — returns structured `unknown_subcommand` error.
- [x] `node ./zerion.js --help | jq '.setup'` — no `setup mcp` entries.
- [ ] CI green on this PR.

Version intentionally stays at `1.0.0` — release-please will pick this up under the next release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)