### PR TITLE
feat: add Monad chain support

### DIFF
--- a/cli/tests/unit/cli/utils/common/validate.test.mjs
+++ b/cli/tests/unit/cli/utils/common/validate.test.mjs
@@ -90,8 +90,8 @@ describe("resolvePositionFilter", () => {
 });
 
 describe("CHAIN_IDS", () => {
-  it("contains 14 chains", () => {
-    assert.equal(CHAIN_IDS.size, 14);
+  it("contains 15 chains", () => {
+    assert.equal(CHAIN_IDS.size, 15);
   });
 
   it("includes key chains", () => {

--- a/cli/utils/chain/registry.js
+++ b/cli/utils/chain/registry.js
@@ -16,6 +16,7 @@ import {
   zkSync,
   zora,
   blast,
+  monad,
 } from "viem/chains";
 
 const CHAIN_MAP = new Map([
@@ -32,6 +33,7 @@ const CHAIN_MAP = new Map([
   ["zksync-era", { viemChain: zkSync, name: "zkSync Era", nativeCurrency: "ETH" }],
   ["zora", { viemChain: zora, name: "Zora", nativeCurrency: "ETH" }],
   ["blast", { viemChain: blast, name: "Blast", nativeCurrency: "ETH" }],
+  ["monad", { viemChain: monad, name: "Monad", nativeCurrency: "MON" }],
 ]);
 
 // Solana (not in CHAIN_MAP since it uses different infra)


### PR DESCRIPTION
## Summary
- Monad (chain ID 143) was missing from CLI chain registry (`registry.js`), causing `getViemChain("monad")` to return null and throw before reaching OWS signing
- Zerion API already marks Monad with `supports_trading/sending/bridge: true`; OWS also handles it via bare numeric EVM fallback — our registry was the only blocker
- Adds `monad` from `viem/chains` to `CHAIN_MAP` and updates the chain count assertion in tests

## Test plan
- [ ] `npm test` — 101/101 pass
- [ ] `node -e "import('./cli/utils/chain/registry.js').then(m => console.log(m.getChain('monad')))"` returns chain ID 143
- [ ] Swap on Monad via CLI resolves correctly end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)