### PR TITLE
feat: integrate subscriptions via tributary

### DIFF
--- a/cli/commands/tributary/create.js
+++ b/cli/commands/tributary/create.js
@@ -1,0 +1,129 @@
+import BN from "bn.js";
+import { PublicKey } from "@solana/web3.js";
+import {
+  getTributarySdk,
+  sendTributaryInstructions,
+} from "../../utils/tributary/sdk.js";
+import {
+  USDC_MINT,
+  DEFAULT_GATEWAY,
+  FREQUENCY_MAP,
+  USDC_DECIMALS,
+} from "../../utils/tributary/constants.js";
+import { encodeMemo } from "../../utils/tributary/format.js";
+import { resolveWallet } from "../../utils/wallet/resolve.js";
+import { print, printError } from "../../utils/common/output.js";
+import { requireAgentToken } from "../../utils/trading/guards.js";
+
+export default async function subscribeCreate(args, flags) {
+  const [amountStr, recipientStr] = args;
+  const interval = flags.interval;
+
+  if (!amountStr || !recipientStr || !interval) {
+    printError(
+      "missing_args",
+      "Usage: zerion subscribe create <amount> <recipient> --interval <frequency>",
+      {
+        example: "zerion subscribe create 10 2Nsnn... --interval monthly",
+      },
+    );
+    process.exit(1);
+  }
+
+  const amount = parseFloat(amountStr);
+  if (Number.isNaN(amount) || amount <= 0) {
+    printError(
+      "invalid_amount",
+      `Amount must be a positive number, got "${amountStr}"`,
+    );
+    process.exit(1);
+  }
+
+  const frequency = FREQUENCY_MAP[interval];
+  if (!frequency) {
+    printError("invalid_interval", `Unknown interval "${interval}"`, {
+      suggestion: `Valid: ${Object.keys(FREQUENCY_MAP).join(", ")}`,
+    });
+    process.exit(1);
+  }
+
+  const { walletName, address } = resolveWallet({
+    ...flags,
+    chain: "solana",
+  });
+
+  const tokenMint = flags.token || USDC_MINT;
+  const gateway = flags.gateway || DEFAULT_GATEWAY;
+  const autoRenew = !flags["no-auto-renew"];
+  const maxRenewals = flags["max-renewals"]
+    ? parseInt(flags["max-renewals"])
+    : null;
+  const memo = encodeMemo(flags.memo, 64);
+
+  const amountSmallest = new BN(
+    Math.round(amount * Math.pow(10, USDC_DECIMALS)),
+  );
+
+  const passphrase = await requireAgentToken(
+    "for Tributary subscription",
+    walletName,
+  );
+
+  const sdk = await getTributarySdk(address);
+
+  try {
+    const instructions = await sdk.createSubscription(
+      new PublicKey(tokenMint),
+      new PublicKey(recipientStr),
+      new PublicKey(gateway),
+      amountSmallest,
+      autoRenew,
+      maxRenewals,
+      frequency,
+      memo,
+    );
+
+    if (flags["dry-run"]) {
+      print({
+        dryRun: true,
+        instructionCount: instructions.length,
+        amount: amountStr,
+        recipient: recipientStr,
+        interval,
+        token: tokenMint,
+        gateway,
+      });
+      return;
+    }
+
+    const txResult = await sendTributaryInstructions(
+      instructions,
+      address,
+      walletName,
+      passphrase,
+    );
+
+    print({
+      subscription: {
+        amount: amountSmallest.toString(),
+        amountHuman: `${amount} USDC`,
+        recipient: recipientStr,
+        gateway,
+        token: tokenMint,
+        interval,
+        autoRenew,
+        maxRenewals,
+      },
+      transaction: {
+        hash: txResult.hash,
+        status: txResult.status,
+      },
+    });
+  } catch (err) {
+    printError(
+      err.code || "subscription_error",
+      `Failed to create subscription: ${err.message}`,
+    );
+    process.exit(1);
+  }
+}

--- a/cli/commands/tributary/delete.js
+++ b/cli/commands/tributary/delete.js
@@ -1,0 +1,72 @@
+import { PublicKey } from "@solana/web3.js";
+import {
+  getTributarySdk,
+  sendTributaryInstructions,
+} from "../../utils/tributary/sdk.js";
+import { USDC_MINT } from "../../utils/tributary/constants.js";
+import { resolveWallet } from "../../utils/wallet/resolve.js";
+import { print, printError } from "../../utils/common/output.js";
+import { requireAgentToken } from "../../utils/trading/guards.js";
+
+export default async function subscribeDelete(args, flags) {
+  const [policyIdStr] = args;
+
+  if (!policyIdStr) {
+    printError("missing_args", "Usage: zerion subscribe delete <policy-id>", {
+      example: "zerion subscribe delete 1 --token <mint>",
+    });
+    process.exit(1);
+  }
+
+  const policyId = parseInt(policyIdStr, 10);
+  if (Number.isNaN(policyId) || policyId < 1) {
+    printError(
+      "invalid_policy_id",
+      `Policy ID must be a positive integer, got "${policyIdStr}"`,
+    );
+    process.exit(1);
+  }
+
+  const { walletName, address } = resolveWallet({
+    ...flags,
+    chain: "solana",
+  });
+
+  const tokenMint = flags.token || USDC_MINT;
+  const passphrase = await requireAgentToken(
+    "for Tributary subscription",
+    walletName,
+  );
+
+  try {
+    const sdk = await getTributarySdk(address);
+
+    const instructions = await sdk.deletePaymentPolicy(
+      new PublicKey(tokenMint),
+      policyId,
+    );
+
+    const txResult = await sendTributaryInstructions(
+      instructions,
+      address,
+      walletName,
+      passphrase,
+    );
+
+    print({
+      action: "delete",
+      policyId,
+      token: tokenMint,
+      transaction: {
+        hash: txResult.hash,
+        status: txResult.status,
+      },
+    });
+  } catch (err) {
+    printError(
+      err.code || "delete_error",
+      `Failed to delete policy ${policyId}: ${err.message}`,
+    );
+    process.exit(1);
+  }
+}

--- a/cli/commands/tributary/list.js
+++ b/cli/commands/tributary/list.js
@@ -1,0 +1,85 @@
+import { PublicKey } from "@solana/web3.js";
+import { getTributarySdk } from "../../utils/tributary/sdk.js";
+import { USDC_MINT, USDC_DECIMALS } from "../../utils/tributary/constants.js";
+import { resolveWallet } from "../../utils/wallet/resolve.js";
+import { print, printError } from "../../utils/common/output.js";
+import {
+  decodePolicyType,
+  decodeStatus,
+  decodeMemo,
+  formatAmount,
+  formatPrettyTable,
+} from "../../utils/tributary/format.js";
+import { isPrettyMode } from "../../utils/common/output.js";
+
+export default async function subscribeList(args, flags) {
+  const { walletName, address } = resolveWallet({
+    ...flags,
+    chain: "solana",
+  });
+
+  const statusFilter = flags.status || "all";
+  const tokenMints = [USDC_MINT];
+  const policies = [];
+
+  try {
+    const sdk = await getTributarySdk(address);
+
+    for (const mint of tokenMints) {
+      const userPaymentPda = sdk.getUserPaymentPda(
+        new PublicKey(address),
+        new PublicKey(mint),
+      );
+      const userPolicies = await sdk.getPaymentPoliciesByUserPayment(
+        userPaymentPda.address,
+      );
+
+      for (const p of userPolicies) {
+        const status = decodeStatus(p.account.status);
+        if (statusFilter !== "all" && status !== statusFilter) continue;
+        policies.push(p);
+      }
+    }
+
+    if (flags.pretty || isPrettyMode()) {
+      process.stdout.write(formatPrettyTable(address, policies));
+    } else {
+      print({
+        wallet: address,
+        count: policies.length,
+        policies: policies.map((p) => {
+          const decoded = decodePolicyType(p.account.policyType);
+          const result = {
+            policyId: p.account.policyId,
+            policyPda: p.publicKey.toString(),
+            ...decoded,
+            status: decodeStatus(p.account.status),
+            recipient: p.account.recipient.toString(),
+            gateway: p.account.gateway.toString(),
+          };
+          if (decoded.type === "subscription") {
+            result.amount = `${formatAmount(decoded.amount, USDC_DECIMALS)} USDC`;
+            result.nextPaymentDue = decoded.nextPaymentDue
+              ? new Date(decoded.nextPaymentDue * 1000).toISOString()
+              : null;
+          }
+          const memo = decodeMemo(p.account.memo);
+          if (memo) result.memo = memo;
+          if (p.account.createdAt) {
+            result.createdAt = new Date(
+              p.account.createdAt.toNumber() * 1000,
+            ).toISOString();
+          }
+          return result;
+        }),
+      });
+    }
+  } catch (err) {
+    console.trace(err)
+    printError(
+      err.code || "list_error",
+      `Failed to list subscriptions: ${err.message}`,
+    );
+    process.exit(1);
+  }
+}

--- a/cli/commands/tributary/pause.js
+++ b/cli/commands/tributary/pause.js
@@ -1,0 +1,73 @@
+import { PublicKey } from "@solana/web3.js";
+import {
+  getTributarySdk,
+  sendTributaryInstructions,
+} from "../../utils/tributary/sdk.js";
+import { USDC_MINT } from "../../utils/tributary/constants.js";
+import { resolveWallet } from "../../utils/wallet/resolve.js";
+import { print, printError } from "../../utils/common/output.js";
+import { requireAgentToken } from "../../utils/trading/guards.js";
+
+export default async function subscribePause(args, flags) {
+  const [policyIdStr] = args;
+
+  if (!policyIdStr) {
+    printError("missing_args", "Usage: zerion subscribe pause <policy-id>", {
+      example: "zerion subscribe pause 1 --token <mint>",
+    });
+    process.exit(1);
+  }
+
+  const policyId = parseInt(policyIdStr, 10);
+  if (Number.isNaN(policyId) || policyId < 1) {
+    printError(
+      "invalid_policy_id",
+      `Policy ID must be a positive integer, got "${policyIdStr}"`,
+    );
+    process.exit(1);
+  }
+
+  const { walletName, address } = resolveWallet({
+    ...flags,
+    chain: "solana",
+  });
+
+  const tokenMint = flags.token || USDC_MINT;
+  const passphrase = await requireAgentToken(
+    "for Tributary subscription",
+    walletName,
+  );
+
+  try {
+    const sdk = await getTributarySdk(address);
+
+    const instructions = await sdk.changePaymentPolicyStatus(
+      new PublicKey(tokenMint),
+      policyId,
+      { paused: {} },
+    );
+
+    const txResult = await sendTributaryInstructions(
+      instructions,
+      address,
+      walletName,
+      passphrase,
+    );
+
+    print({
+      action: "pause",
+      policyId,
+      token: tokenMint,
+      transaction: {
+        hash: txResult.hash,
+        status: txResult.status,
+      },
+    });
+  } catch (err) {
+    printError(
+      err.code || "pause_error",
+      `Failed to pause policy ${policyId}: ${err.message}`,
+    );
+    process.exit(1);
+  }
+}

--- a/cli/commands/tributary/resume.js
+++ b/cli/commands/tributary/resume.js
@@ -1,0 +1,73 @@
+import { PublicKey } from "@solana/web3.js";
+import {
+  getTributarySdk,
+  sendTributaryInstructions,
+} from "../../utils/tributary/sdk.js";
+import { USDC_MINT } from "../../utils/tributary/constants.js";
+import { resolveWallet } from "../../utils/wallet/resolve.js";
+import { print, printError } from "../../utils/common/output.js";
+import { requireAgentToken } from "../../utils/trading/guards.js";
+
+export default async function subscribeResume(args, flags) {
+  const [policyIdStr] = args;
+
+  if (!policyIdStr) {
+    printError("missing_args", "Usage: zerion subscribe resume <policy-id>", {
+      example: "zerion subscribe resume 1 --token <mint>",
+    });
+    process.exit(1);
+  }
+
+  const policyId = parseInt(policyIdStr, 10);
+  if (Number.isNaN(policyId) || policyId < 1) {
+    printError(
+      "invalid_policy_id",
+      `Policy ID must be a positive integer, got "${policyIdStr}"`,
+    );
+    process.exit(1);
+  }
+
+  const { walletName, address } = resolveWallet({
+    ...flags,
+    chain: "solana",
+  });
+
+  const tokenMint = flags.token || USDC_MINT;
+  const passphrase = await requireAgentToken(
+    "for Tributary subscription",
+    walletName,
+  );
+
+  try {
+    const sdk = await getTributarySdk(address);
+
+    const instructions = await sdk.changePaymentPolicyStatus(
+      new PublicKey(tokenMint),
+      policyId,
+      { active: {} },
+    );
+
+    const txResult = await sendTributaryInstructions(
+      instructions,
+      address,
+      walletName,
+      passphrase,
+    );
+
+    print({
+      action: "resume",
+      policyId,
+      token: tokenMint,
+      transaction: {
+        hash: txResult.hash,
+        status: txResult.status,
+      },
+    });
+  } catch (err) {
+    printError(
+      err.code || "resume_error",
+      `Failed to resume policy ${policyId}: ${err.message}`,
+    );
+    process.exit(1);
+  }
+}

--- a/cli/commands/tributary/show.js
+++ b/cli/commands/tributary/show.js
@@ -1,0 +1,93 @@
+import { PublicKey } from "@solana/web3.js";
+import { getTributarySdk } from "../../utils/tributary/sdk.js";
+import { USDC_MINT, USDC_DECIMALS } from "../../utils/tributary/constants.js";
+import { resolveWallet } from "../../utils/wallet/resolve.js";
+import { print, printError } from "../../utils/common/output.js";
+import {
+  decodePolicyType,
+  decodeStatus,
+  decodeMemo,
+  formatAmount,
+} from "../../utils/tributary/format.js";
+
+export default async function subscribeShow(args, flags) {
+  const [policyIdStr] = args;
+
+  if (!policyIdStr) {
+    printError("missing_args", "Usage: zerion subscribe show <policy-id>", {
+      example: "zerion subscribe show 1",
+    });
+    process.exit(1);
+  }
+
+  const policyId = parseInt(policyIdStr, 10);
+  if (Number.isNaN(policyId) || policyId < 1) {
+    printError(
+      "invalid_policy_id",
+      `Policy ID must be a positive integer, got "${policyIdStr}"`,
+    );
+    process.exit(1);
+  }
+
+  const { walletName, address } = resolveWallet({
+    ...flags,
+    chain: "solana",
+  });
+
+  const tokenMint = flags.token || USDC_MINT;
+
+  try {
+    const sdk = await getTributarySdk(address);
+
+    const userPaymentPda = sdk.getUserPaymentPda(
+      new PublicKey(address),
+      new PublicKey(tokenMint),
+    );
+    const policyPda = sdk.getPaymentPolicyPda(userPaymentPda.address, policyId);
+
+    const policy = await sdk.getPaymentPolicy(policyPda.address);
+
+    if (!policy) {
+      printError(
+        "policy_not_found",
+        `Policy ${policyId} not found for wallet ${address}`,
+      );
+      process.exit(1);
+    }
+
+    const decoded = decodePolicyType(policy.account.policyType);
+    const status = decodeStatus(policy.account.status);
+    const memo = decodeMemo(policy.account.memo);
+
+    const result = {
+      policyId: policy.account.policyId,
+      policyPda: policy.publicKey.toString(),
+      ...decoded,
+      status,
+      recipient: policy.account.recipient.toString(),
+      gateway: policy.account.gateway.toString(),
+      token: tokenMint,
+    };
+
+    if (decoded.type === "subscription") {
+      result.amount = `${formatAmount(decoded.amount, USDC_DECIMALS)} USDC`;
+      result.nextPaymentDue = decoded.nextPaymentDue
+        ? new Date(decoded.nextPaymentDue * 1000).toISOString()
+        : null;
+    }
+    if (memo) result.memo = memo;
+    if (policy.account.createdAt) {
+      result.createdAt = new Date(
+        policy.account.createdAt.toNumber() * 1000,
+      ).toISOString();
+    }
+
+    print(result);
+  } catch (err) {
+    printError(
+      err.code || "show_error",
+      `Failed to show policy: ${err.message}`,
+    );
+    process.exit(1);
+  }
+}

--- a/cli/router.js
+++ b/cli/router.js
@@ -69,6 +69,16 @@ function printUsage() {
       "agent show-policy <id>": "Show policy details",
       "agent delete-policy <id>": "Delete a policy",
     },
+    tributary: {
+      "subscribe create <amount> <recipient> --interval <frequency>":
+        "Create on-chain recurring subscription (Solana + Tributary)",
+      "subscribe list [--status active|paused|all] [--pretty]":
+        "List payment policies for wallet",
+      "subscribe show <policy-id>": "Show single policy details",
+      "subscribe pause <policy-id>": "Pause a payment policy",
+      "subscribe resume <policy-id>": "Resume a paused policy",
+      "subscribe delete <policy-id>": "Permanently delete a policy",
+    },
     watchlist: {
       "watch <address> --name <label>": "Add wallet to watchlist",
       "watch list": "List watched wallets",

--- a/cli/utils/tributary/constants.js
+++ b/cli/utils/tributary/constants.js
@@ -1,0 +1,20 @@
+export const TRIBUTARY_PROGRAM_ID =
+  "TRibg8W8zmPHQqWtyAD1rEBRXEdyU13Mu6qX1Sg42tJ";
+
+// USDC
+//export const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+// USDC on devnet
+export const USDC_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+
+
+export const DEFAULT_GATEWAY = "CwNybLVQ3sVmcZ3Q1veS6x99gUZcAF2duNDe3qbcEMGr";
+export const USDC_DECIMALS = 6;
+
+export const FREQUENCY_MAP = {
+  daily: { daily: {} },
+  weekly: { weekly: {} },
+  monthly: { monthly: {} },
+  quarterly: { quarterly: {} },
+  "semi-annually": { semiAnnually: {} },
+  annually: { annually: {} },
+};

--- a/cli/utils/tributary/format.js
+++ b/cli/utils/tributary/format.js
@@ -1,0 +1,149 @@
+export function decodePolicyType(policyType) {
+  if ("subscription" in policyType) {
+    const sub = policyType.subscription;
+    return {
+      type: "subscription",
+      amount: sub.amount.toString(),
+      autoRenew: sub.autoRenew,
+      maxRenewals: sub.maxRenewals,
+      frequency: decodeFrequency(sub.paymentFrequency),
+      nextPaymentDue: sub.nextPaymentDue.toNumber(),
+    };
+  }
+  if ("milestone" in policyType) {
+    const ms = policyType.milestone;
+    return {
+      type: "milestone",
+      amounts: ms.milestoneAmounts.map((a) => a.toString()),
+      timestamps: ms.milestoneTimestamps.map((t) => t.toNumber()),
+      currentMilestone: ms.currentMilestone,
+      totalMilestones: ms.totalMilestones,
+      escrowAmount: ms.escrowAmount.toString(),
+    };
+  }
+  if ("payAsYouGo" in policyType) {
+    const payg = policyType.payAsYouGo;
+    return {
+      type: "payAsYouGo",
+      maxPerPeriod: payg.maxAmountPerPeriod.toString(),
+      maxChunk: payg.maxChunkAmount.toString(),
+      periodSeconds: payg.periodLengthSeconds.toNumber(),
+      periodStart: payg.currentPeriodStart.toNumber(),
+      periodTotal: payg.currentPeriodTotal.toString(),
+    };
+  }
+  return { type: "unknown" };
+}
+
+export function formatAmount(smallestUnits, decimals = 6) {
+  const raw = Number(smallestUnits) / Math.pow(10, decimals);
+  return raw.toFixed(decimals > 2 ? 2 : decimals);
+}
+
+export function decodeFrequency(freq) {
+  if ("daily" in freq) return "daily";
+  if ("weekly" in freq) return "weekly";
+  if ("monthly" in freq) return "monthly";
+  if ("quarterly" in freq) return "quarterly";
+  if ("semiAnnually" in freq) return "semi-annually";
+  if ("annually" in freq) return "annually";
+  if ("custom" in freq) return `custom (${freq.custom.seconds}s)`;
+  return "unknown";
+}
+
+export function decodeStatus(status) {
+  if ("active" in status) return "active";
+  if ("paused" in status) return "paused";
+  return "unknown";
+}
+
+export function decodeMemo(memoBytes) {
+  if (!memoBytes || !memoBytes.length) return "";
+  const buf = Buffer.from(memoBytes);
+  const firstZero = buf.indexOf(0);
+  if (firstZero === 0) return "";
+  return buf.slice(0, firstZero >= 0 ? firstZero : undefined).toString("utf-8");
+}
+
+export function encodeMemo(memo, maxLength = 64) {
+  const encoded = Buffer.from(memo || "", "utf-8");
+  const padded = Buffer.alloc(maxLength);
+  encoded.copy(padded);
+  return Array.from(padded);
+}
+
+export function formatPolicyRow(policy, decimals = 6) {
+  const decoded = decodePolicyType(policy.account.policyType);
+  const status = decodeStatus(policy.account.status);
+  const typeLabel =
+    decoded.type === "subscription"
+      ? "sub"
+      : decoded.type === "payAsYouGo"
+        ? "payg"
+        : decoded.type === "milestone"
+          ? "mile"
+          : "?";
+
+  let amount, interval;
+  if (decoded.type === "subscription") {
+    amount = `${formatAmount(decoded.amount, decimals)} USDC`;
+    interval = decoded.frequency;
+  } else if (decoded.type === "payAsYouGo") {
+    amount = `${formatAmount(decoded.maxPerPeriod, decimals)}/cap`;
+    interval = formatPeriod(decoded.periodSeconds);
+  } else {
+    amount = `${formatAmount(decoded.escrowAmount, decimals)} escrow`;
+    interval = "-";
+  }
+
+  const nextDue =
+    decoded.type === "subscription" && decoded.nextPaymentDue
+      ? new Date(decoded.nextPaymentDue * 1000).toLocaleDateString("en-US", {
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+        })
+      : "-";
+
+  return {
+    id: policy.account.policyId,
+    type: typeLabel,
+    amount,
+    interval,
+    nextDue,
+    status,
+  };
+}
+
+export function formatPeriod(seconds) {
+  if (seconds === 86400) return "24h";
+  if (seconds === 604800) return "7d";
+  if (seconds === 2592000) return "30d";
+  if (seconds >= 86400) return `${Math.round(seconds / 86400)}d`;
+  if (seconds >= 3600) return `${Math.round(seconds / 3600)}h`;
+  return `${seconds}s`;
+}
+
+export function formatPrettyTable(address, policies) {
+  const shortAddr = address.slice(0, 6) + "..." + address.slice(-4);
+  const rows = policies.map((p) => {
+    const row = formatPolicyRow(p);
+    return `│ ${String(row.id).padEnd(4)} │ ${row.type.padEnd(8)} │ ${row.amount.padEnd(8)} │ ${row.interval.padEnd(9)} │ ${row.nextDue.padEnd(11)} │ ${row.status.padEnd(11)} │`;
+  });
+
+  const header =
+    "│ ID   │ Type     │ Amount   │ Interval  │ Next Due    │ Status      │";
+  const sep =
+    "├──────┼──────────┼──────────┼───────────┼─────────────┼─────────────┤";
+
+  let table = `╭─────────────────────────────────────────────────────────────────────╮\n`;
+  table += `│  Tributary Subscriptions — wallet: ${shortAddr.padEnd(32)}│\n`;
+  table += `├──────┬──────────┬──────────┬───────────┬─────────────┬─────────────┤\n`;
+  table += `${header}\n`;
+  table += `${sep}\n`;
+  for (const row of rows) {
+    table += `${row}\n`;
+  }
+  table += `╰──────┴──────────┴──────────┴───────────┴─────────────┴─────────────╯\n`;
+  return table;
+}

--- a/cli/utils/tributary/sdk.js
+++ b/cli/utils/tributary/sdk.js
@@ -1,0 +1,165 @@
+import {
+  Connection,
+  PublicKey,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import { Tributary } from "@tributary-so/sdk";
+import { Buffer } from "node:buffer";
+import { getSolanaRpcUrl } from "../chain/registry.js";
+import * as ows from "../wallet/keystore.js";
+
+let _connection;
+function getConnection() {
+  if (!_connection) {
+    _connection = new Connection(getSolanaRpcUrl(), "confirmed");
+  }
+  return _connection;
+}
+
+export async function getTributarySdk(walletPubkey) {
+  const connection = getConnection();
+  const pubkey = new PublicKey(walletPubkey);
+
+  const walletAdapter = {
+    publicKey: pubkey,
+    signTransaction: async () => {
+      throw new Error(
+        "Direct signing not supported — use sendTributaryInstructions",
+      );
+    },
+    signAllTransactions: async () => {
+      throw new Error(
+        "Direct signing not supported — use sendTributaryInstructions",
+      );
+    },
+  };
+
+  const sdk = new Tributary(connection, walletAdapter);
+
+  return {
+    program: sdk.program,
+    programId: sdk.programId,
+    connection,
+    walletPubkey: pubkey,
+
+    async createSubscription(
+      tokenMint,
+      recipient,
+      gateway,
+      amount,
+      autoRenew,
+      maxRenewals,
+      frequency,
+      memo,
+    ) {
+      return sdk.createSubscription(
+        tokenMint,
+        recipient,
+        gateway,
+        amount,
+        autoRenew,
+        maxRenewals,
+        frequency,
+        memo,
+      );
+    },
+
+    async getPaymentPoliciesByUserPayment(userPaymentPda) {
+      return sdk.getPaymentPoliciesByUserPayment(userPaymentPda);
+    },
+
+    async getPaymentPolicy(policyPda) {
+      return sdk.getPaymentPolicy(policyPda);
+    },
+
+    getUserPaymentPda(owner, tokenMint) {
+      return sdk.getUserPaymentPda(owner, tokenMint);
+    },
+
+    getPaymentPolicyPda(userPaymentPda, policyId) {
+      return sdk.getPaymentPolicyPda(userPaymentPda, policyId);
+    },
+
+    async changePaymentPolicyStatus(tokenMint, policyId, status) {
+      const ix = await sdk.changePaymentPolicyStatus(
+        tokenMint,
+        policyId,
+        status,
+      );
+      return [ix];
+    },
+
+    async deletePaymentPolicy(tokenMint, policyId) {
+      const ix = await sdk.deletePaymentPolicy(tokenMint, policyId);
+      return [ix];
+    },
+  };
+}
+
+export async function getTributarySdkReadOnly(walletPubkey) {
+  return getTributarySdk(walletPubkey);
+}
+
+export async function sendTributaryInstructions(
+  instructions,
+  payerKey,
+  walletName,
+  passphrase,
+) {
+  const connection = getConnection();
+  const payer = new PublicKey(payerKey);
+
+  const { blockhash, lastValidBlockHeight } =
+    await connection.getLatestBlockhash("confirmed");
+
+  const message = new TransactionMessage({
+    payerKey: payer,
+    recentBlockhash: blockhash,
+    instructions,
+  }).compileToV0Message();
+
+  const tx = new VersionedTransaction(message);
+  const rawWithPlaceholder = Buffer.from(tx.serialize());
+
+  const signRes = ows.signSolanaTransaction(
+    walletName,
+    rawWithPlaceholder.toString("hex"),
+    passphrase,
+  );
+  const signatureBytes = Buffer.from(signRes.signature, "hex");
+
+  if (signatureBytes.length !== 64) {
+    throw new Error(
+      `Unexpected Solana signature length: ${signatureBytes.length}`,
+    );
+  }
+
+  const sigCount = rawWithPlaceholder[0];
+  if (sigCount !== 1) {
+    throw new Error(
+      `Unsupported tx with ${sigCount} signatures (only single-signer supported)`,
+    );
+  }
+
+  const messageBytes = rawWithPlaceholder.subarray(1 + 64);
+  const signedTxBytes = Buffer.concat([
+    Buffer.from([1]),
+    signatureBytes,
+    messageBytes,
+  ]);
+
+  process.stderr.write("Broadcasting Tributary transaction...\n");
+  const hash = await connection.sendRawTransaction(signedTxBytes, {
+    skipPreflight: false,
+    preflightCommitment: "confirmed",
+  });
+
+  process.stderr.write(`Tx hash: ${hash}\nWaiting for confirmation...\n`);
+  await connection.confirmTransaction(
+    { signature: hash, blockhash, lastValidBlockHeight },
+    "confirmed",
+  );
+
+  return { hash, status: "confirmed" };
+}

--- a/cli/zerion.js
+++ b/cli/zerion.js
@@ -87,6 +87,21 @@ register("agent", "list-policies", agentListPolicies);
 register("agent", "show-policy", agentShowPolicy);
 register("agent", "delete-policy", agentDeletePolicy);
 
+// --- Tributary subscriptions (on-chain recurring payments on Solana) ---
+
+import subscribeCreate from "./commands/tributary/create.js";
+import subscribeList from "./commands/tributary/list.js";
+import subscribeShow from "./commands/tributary/show.js";
+import subscribePause from "./commands/tributary/pause.js";
+import subscribeResume from "./commands/tributary/resume.js";
+import subscribeDelete from "./commands/tributary/delete.js";
+register("subscribe", "create", subscribeCreate);
+register("subscribe", "list", subscribeList);
+register("subscribe", "show", subscribeShow);
+register("subscribe", "pause", subscribePause);
+register("subscribe", "resume", subscribeResume);
+register("subscribe", "delete", subscribeDelete);
+
 // --- Config ---
 
 import configCmd from "./commands/config.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@open-wallet-standard/core": "^1.2.4",
         "@solana/web3.js": "^1.98.4",
-        "@tributary-so/sdk": "^1.1.0",
+        "@tributary-so/sdk": "^1.12.0",
         "@x402/evm": "^2.6.0",
         "@x402/fetch": "^2.6.0",
         "@x402/svm": "^2.8.0",
@@ -46,8 +46,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
       "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@coral-xyz/anchor": {
       "version": "0.31.1",
@@ -142,7 +141,6 @@
       "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi/-/umi-1.5.1.tgz",
       "integrity": "sha512-ONRv5a0kv+23AMlR8oyFBHnjVg3o3N8pUfFcV4gzbg6OgZf87zHsPWBfED3OTJqx267v1bEn6d6DABXNFq9Z3A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@metaplex-foundation/umi-options": "^1.5.1",
         "@metaplex-foundation/umi-public-keys": "^1.5.1",
@@ -571,6 +569,7 @@
       "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-5.5.1.tgz",
       "integrity": "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/codecs-core": "5.5.1",
@@ -596,6 +595,7 @@
       "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-5.5.1.tgz",
       "integrity": "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/assertions": "5.5.1",
         "@solana/codecs-core": "5.5.1",
@@ -620,6 +620,7 @@
       "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-5.5.1.tgz",
       "integrity": "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1"
       },
@@ -667,6 +668,7 @@
       "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-5.5.1.tgz",
       "integrity": "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "5.5.1",
         "@solana/codecs-data-structures": "5.5.1",
@@ -691,6 +693,7 @@
       "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-5.5.1.tgz",
       "integrity": "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1"
       },
@@ -711,6 +714,7 @@
       "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-5.5.1.tgz",
       "integrity": "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "5.5.1",
         "@solana/codecs-numbers": "5.5.1",
@@ -733,6 +737,7 @@
       "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-5.5.1.tgz",
       "integrity": "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "5.5.1",
         "@solana/errors": "5.5.1"
@@ -754,6 +759,7 @@
       "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-5.5.1.tgz",
       "integrity": "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "5.5.1",
         "@solana/codecs-numbers": "5.5.1",
@@ -780,6 +786,7 @@
       "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-5.5.1.tgz",
       "integrity": "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "5.6.2",
         "commander": "14.0.2"
@@ -804,6 +811,7 @@
       "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-5.5.1.tgz",
       "integrity": "sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -821,6 +829,7 @@
       "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-5.5.1.tgz",
       "integrity": "sha512-tTHoJcEQq3gQx5qsdsDJ0LEJeFzwNpXD80xApW9o/PPoCNimI3SALkZl+zNW8VnxRrV3l3yYvfHWBKe/X3WG3w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -838,6 +847,7 @@
       "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-5.5.1.tgz",
       "integrity": "sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1",
         "@solana/instructions": "5.5.1",
@@ -863,6 +873,7 @@
       "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-5.5.1.tgz",
       "integrity": "sha512-h0G1CG6S+gUUSt0eo6rOtsaXRBwCq1+Js2a+Ps9Bzk9q7YHNFA75/X0NWugWLgC92waRp66hrjMTiYYnLBoWOQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "5.5.1",
         "@solana/errors": "5.5.1"
@@ -884,6 +895,7 @@
       "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-5.5.1.tgz",
       "integrity": "sha512-KRD61cL7CRL+b4r/eB9dEoVxIf/2EJ1Pm1DmRYhtSUAJD2dJ5Xw8QFuehobOGm9URqQ7gaQl+Fkc1qvDlsWqKg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/assertions": "5.5.1",
         "@solana/codecs-core": "5.5.1",
@@ -950,6 +962,7 @@
       "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-5.5.1.tgz",
       "integrity": "sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -967,6 +980,7 @@
       "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-5.5.1.tgz",
       "integrity": "sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/codecs-core": "5.5.1",
@@ -994,6 +1008,7 @@
       "resolved": "https://registry.npmjs.org/@solana/options/-/options-5.5.1.tgz",
       "integrity": "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "5.5.1",
         "@solana/codecs-data-structures": "5.5.1",
@@ -1018,6 +1033,7 @@
       "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-5.5.1.tgz",
       "integrity": "sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -1035,6 +1051,7 @@
       "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-5.5.1.tgz",
       "integrity": "sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/errors": "5.5.1"
@@ -1056,6 +1073,7 @@
       "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-5.5.1.tgz",
       "integrity": "sha512-T9lfuUYkGykJmppEcssNiCf6yiYQxJkhiLPP+pyAc2z84/7r3UVIb2tNJk4A9sucS66pzJnVHZKcZVGUUp6wzA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -1073,6 +1091,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-5.5.1.tgz",
       "integrity": "sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1",
         "@solana/fast-stable-stringify": "5.5.1",
@@ -1101,6 +1120,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-5.5.1.tgz",
       "integrity": "sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/codecs-core": "5.5.1",
@@ -1131,6 +1151,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-5.5.1.tgz",
       "integrity": "sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -1148,6 +1169,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-5.5.1.tgz",
       "integrity": "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1",
         "@solana/rpc-spec-types": "5.5.1"
@@ -1169,6 +1191,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-5.5.1.tgz",
       "integrity": "sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -1186,6 +1209,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-5.5.1.tgz",
       "integrity": "sha512-CTMy5bt/6mDh4tc6vUJms9EcuZj3xvK0/xq8IQ90rhkpYvate91RjBP+egvjgSayUg9yucU9vNuUpEjz4spM7w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1",
         "@solana/fast-stable-stringify": "5.5.1",
@@ -1216,6 +1240,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-5.5.1.tgz",
       "integrity": "sha512-5Oi7k+GdeS8xR2ly1iuSFkAv6CZqwG0Z6b1QZKbEgxadE1XGSDrhM2cn59l+bqCozUWCqh4c/A2znU/qQjROlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/keys": "5.5.1",
@@ -1242,6 +1267,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-5.5.1.tgz",
       "integrity": "sha512-7tGfBBrYY8TrngOyxSHoCU5shy86iA9SRMRrPSyBhEaZRAk6dnbdpmUTez7gtdVo0BCvh9nzQtUycKWSS7PnFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1",
         "@solana/functional": "5.5.1",
@@ -1266,6 +1292,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-5.5.1.tgz",
       "integrity": "sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1",
         "@solana/promises": "5.5.1",
@@ -1289,6 +1316,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-5.5.1.tgz",
       "integrity": "sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1",
         "@solana/functional": "5.5.1",
@@ -1313,6 +1341,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-5.5.1.tgz",
       "integrity": "sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1",
         "@solana/rpc-spec": "5.5.1",
@@ -1336,6 +1365,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-5.5.1.tgz",
       "integrity": "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/codecs-core": "5.5.1",
@@ -1361,6 +1391,7 @@
       "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-5.5.1.tgz",
       "integrity": "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/codecs-core": "5.5.1",
@@ -1660,6 +1691,7 @@
       "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-5.5.1.tgz",
       "integrity": "sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "5.5.1"
       },
@@ -1704,6 +1736,7 @@
       "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-5.5.1.tgz",
       "integrity": "sha512-j4mKlYPHEyu+OD7MBt3jRoX4ScFgkhZC6H65on4Fux6LMScgivPJlwnKoZMnsgxFgWds0pl+BYzSiALDsXlYtw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/codecs-strings": "5.5.1",
@@ -1733,6 +1766,7 @@
       "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-5.5.1.tgz",
       "integrity": "sha512-aXyhMCEaAp3M/4fP0akwBBQkFPr4pfwoC5CLDq999r/FUwDax2RE/h4Ic7h2Xk+JdcUwsb+rLq85Y52hq84XvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/codecs-core": "5.5.1",
@@ -1761,6 +1795,7 @@
       "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-5.5.1.tgz",
       "integrity": "sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "5.5.1",
         "@solana/codecs-core": "5.5.1",
@@ -1792,7 +1827,6 @@
       "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz",
       "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "@noble/curves": "^1.4.2",
@@ -1877,9 +1911,9 @@
       "license": "MIT"
     },
     "node_modules/@tributary-so/sdk": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@tributary-so/sdk/-/sdk-1.4.0.tgz",
-      "integrity": "sha512-n7I9D7OET4gCwcCyhVkgMJaWetePLsUACY5LofJEu8BWHk7vdSK8/Qj0dWqc5hjoWl8NbkFPdkF5xepdXvR2UA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@tributary-so/sdk/-/sdk-1.12.0.tgz",
+      "integrity": "sha512-yzkfeSS8nTpZmdYGi9Zipl4mHAW8Uf83MaTWk5HS9T31SlsEyZz7+L5TooEBznwqjXdMyz9e2nrDHQ6bkv+HhA==",
       "license": "MIT",
       "dependencies": {
         "@coral-xyz/anchor": "^0.31.0",
@@ -2127,6 +2161,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.5"
+      }
+    },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/camelcase": {
@@ -2665,7 +2713,8 @@
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.25.0.tgz",
       "integrity": "sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/utf-8-validate": {
       "version": "6.0.6",
@@ -2705,7 +2754,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -2833,7 +2881,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,11 @@
       "dependencies": {
         "@open-wallet-standard/core": "^1.2.4",
         "@solana/web3.js": "^1.98.4",
+        "@tributary-so/sdk": "^1.1.0",
         "@x402/evm": "^2.6.0",
         "@x402/fetch": "^2.6.0",
         "@x402/svm": "^2.8.0",
+        "bn.js": "^5.2.2",
         "mppx": "^0.6.2",
         "qrcode-terminal": "^0.12.0",
         "viem": "^2.0.0"
@@ -46,6 +48,280 @@
       "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@coral-xyz/anchor": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.31.1.tgz",
+      "integrity": "sha512-QUqpoEK+gi2S6nlYc2atgT2r41TT3caWr/cPUEL8n8Md9437trZ68STknq897b82p5mW0XrTBNOzRbmIRJtfsA==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@coral-xyz/anchor-errors": "^0.31.1",
+        "@coral-xyz/borsh": "^0.31.1",
+        "@noble/hashes": "^1.3.1",
+        "@solana/web3.js": "^1.69.0",
+        "bn.js": "^5.1.2",
+        "bs58": "^4.0.1",
+        "buffer-layout": "^1.2.2",
+        "camelcase": "^6.3.0",
+        "cross-fetch": "^3.1.5",
+        "eventemitter3": "^4.0.7",
+        "pako": "^2.0.3",
+        "superstruct": "^0.15.4",
+        "toml": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=17"
+      }
+    },
+    "node_modules/@coral-xyz/anchor-errors": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor-errors/-/anchor-errors-0.31.1.tgz",
+      "integrity": "sha512-NhNEku4F3zzUSBtrYz84FzYWm48+9OvmT1Hhnwr6GnPQry2dsEqH/ti/7ASjjpoFTWRnPXrjAIT1qM6Isop+LQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@coral-xyz/anchor/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/@coral-xyz/anchor/node_modules/superstruct": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.5.tgz",
+      "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ==",
+      "license": "MIT"
+    },
+    "node_modules/@coral-xyz/borsh": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.31.1.tgz",
+      "integrity": "sha512-9N8AU9F0ubriKfNE3g1WF0/4dtlGXoBN/hd1PvbNBamBNwRgHxH4P+o3Zt7rSEloW1HUs6LfZEchlx9fW7POYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.1.2",
+        "buffer-layout": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.69.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@metaplex-foundation/mpl-token-metadata": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-metadata/-/mpl-token-metadata-3.4.0.tgz",
+      "integrity": "sha512-AxBAYCK73JWxY3g9//z/C9krkR0t1orXZDknUPS4+GjwGH2vgPfsk04yfZ31Htka2AdS9YE/3wH7sMUBHKn9Rg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@metaplex-foundation/mpl-toolbox": "^0.10.0"
+      },
+      "peerDependencies": {
+        "@metaplex-foundation/umi": ">= 0.8.2 <= 1"
+      }
+    },
+    "node_modules/@metaplex-foundation/mpl-toolbox": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-toolbox/-/mpl-toolbox-0.10.0.tgz",
+      "integrity": "sha512-84KD1L5cFyw5xnntHwL4uPwfcrkKSiwuDeypiVr92qCUFuF3ZENa2zlFVPu+pQcjTlod2LmEX3MhBmNjRMpdKg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@metaplex-foundation/umi": ">= 0.8.2 <= 1"
+      }
+    },
+    "node_modules/@metaplex-foundation/umi": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi/-/umi-1.5.1.tgz",
+      "integrity": "sha512-ONRv5a0kv+23AMlR8oyFBHnjVg3o3N8pUfFcV4gzbg6OgZf87zHsPWBfED3OTJqx267v1bEn6d6DABXNFq9Z3A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@metaplex-foundation/umi-options": "^1.5.1",
+        "@metaplex-foundation/umi-public-keys": "^1.5.1",
+        "@metaplex-foundation/umi-serializers": "^1.5.1"
+      }
+    },
+    "node_modules/@metaplex-foundation/umi-bundle-defaults": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-bundle-defaults/-/umi-bundle-defaults-1.5.1.tgz",
+      "integrity": "sha512-7qoXenAkQbcj468HGAeLZDyg3eEhcS9rWAnGqjnKgWOlL1czL2Qwho0FEtqOv57IHwAJSTpbHbcvABmdpTjjdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@metaplex-foundation/umi-downloader-http": "^1.5.1",
+        "@metaplex-foundation/umi-eddsa-web3js": "^1.5.1",
+        "@metaplex-foundation/umi-http-fetch": "^1.5.1",
+        "@metaplex-foundation/umi-program-repository": "^1.5.1",
+        "@metaplex-foundation/umi-rpc-chunk-get-accounts": "^1.5.1",
+        "@metaplex-foundation/umi-rpc-web3js": "^1.5.1",
+        "@metaplex-foundation/umi-serializer-data-view": "^1.5.1",
+        "@metaplex-foundation/umi-transaction-factory-web3js": "^1.5.1"
+      },
+      "peerDependencies": {
+        "@metaplex-foundation/umi": "^1.5.1",
+        "@solana/web3.js": "^1.72.0"
+      }
+    },
+    "node_modules/@metaplex-foundation/umi-downloader-http": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-downloader-http/-/umi-downloader-http-1.5.1.tgz",
+      "integrity": "sha512-1s9gSTaDtwELyxBRE6Wmdr3xWeb4Z1uU04dj3Hg8VU+TN6/3wchh93+rIGZT5D3zzdh4+yPxdYV+4ZEr3T5glQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@metaplex-foundation/umi": "^1.5.1"
+      }
+    },
+    "node_modules/@metaplex-foundation/umi-eddsa-web3js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-eddsa-web3js/-/umi-eddsa-web3js-1.5.1.tgz",
+      "integrity": "sha512-ZlzmXXAa1Ujk00G5TmqXM81J25+k/8sqt0zxBUlLTUSOxzlhxhlUKdErIhpHazbKq+eGck+Onm17oAwVKdKAcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@metaplex-foundation/umi-web3js-adapters": "^1.5.1",
+        "@noble/curves": "^1.0.0",
+        "yaml": "^2.7.0"
+      },
+      "peerDependencies": {
+        "@metaplex-foundation/umi": "^1.5.1",
+        "@solana/web3.js": "^1.72.0"
+      }
+    },
+    "node_modules/@metaplex-foundation/umi-http-fetch": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-http-fetch/-/umi-http-fetch-1.5.1.tgz",
+      "integrity": "sha512-AOjZJo3Ua4a2FvgA85x5f0TkMSb+13Ao3uLIQ9FbScV42kqZnDox8KjJ7tKm1ZtYDlCYD0pSFMKPOC9NPDnHDg==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.7"
+      },
+      "peerDependencies": {
+        "@metaplex-foundation/umi": "^1.5.1"
+      }
+    },
+    "node_modules/@metaplex-foundation/umi-options": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-options/-/umi-options-1.5.1.tgz",
+      "integrity": "sha512-ZE6uXgFA3rElFq4gJxZM2diAqZdFqL65bOnAggwdnnei5XXRzFyNF16wYSqlHnPLvG6ohRHWiXww8d2Mb83xFg==",
+      "license": "MIT"
+    },
+    "node_modules/@metaplex-foundation/umi-program-repository": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-program-repository/-/umi-program-repository-1.5.1.tgz",
+      "integrity": "sha512-E5W0IjwFgDGuBTshISbbEh/s8deqxcOzzEjOOlYdMXnevVsfNLwBBIAY4NPJg3v5vpFlKODwUGB5BxCUVthzJg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@metaplex-foundation/umi": "^1.5.1"
+      }
+    },
+    "node_modules/@metaplex-foundation/umi-public-keys": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-public-keys/-/umi-public-keys-1.5.1.tgz",
+      "integrity": "sha512-joTnI1mRtYRfIaTo98uaYRjBPszsdyHuq0vvd6QbSX+MPvu3enkWi+UicuykEc3VXd5tcGdNMiGSx4jgXG6pkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@metaplex-foundation/umi-serializers-encodings": "^1.5.1"
+      }
+    },
+    "node_modules/@metaplex-foundation/umi-rpc-chunk-get-accounts": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-rpc-chunk-get-accounts/-/umi-rpc-chunk-get-accounts-1.5.1.tgz",
+      "integrity": "sha512-3dnGobT1Xwul7fXzQr8660UHSnFOCWEed4T449oNekrVsHp2o00fdOqjXwo11DYhS1rjm+gbzRSazRKb62uF2Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@metaplex-foundation/umi": "^1.5.1"
+      }
+    },
+    "node_modules/@metaplex-foundation/umi-rpc-web3js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-rpc-web3js/-/umi-rpc-web3js-1.5.1.tgz",
+      "integrity": "sha512-CxHyruh2gW2b/ZOwHFFtooOgtu9hBrOJTd3HUMtD/jpaturApa3itsL/zNt4K34tELzVIUL7N78LDjNpzbu9Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@metaplex-foundation/umi-web3js-adapters": "^1.5.1"
+      },
+      "peerDependencies": {
+        "@metaplex-foundation/umi": "^1.5.1",
+        "@solana/web3.js": "^1.72.0"
+      }
+    },
+    "node_modules/@metaplex-foundation/umi-serializer-data-view": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-serializer-data-view/-/umi-serializer-data-view-1.5.1.tgz",
+      "integrity": "sha512-9Wxqk3bGVJ0xNmHhHrOUhdu/90Q1IT3FZRZN4eGckb0sf7Bgls7kBTkFfgXFmUh2VBnE0GnnncXeHKtop5RSFA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@metaplex-foundation/umi": "^1.5.1"
+      }
+    },
+    "node_modules/@metaplex-foundation/umi-serializers": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-serializers/-/umi-serializers-1.5.1.tgz",
+      "integrity": "sha512-scXciBylbJ4iwfxOF1Xx2XiBzoYUD8fSKWTsMal5Rj1hMRDe6b2XZcsBOjio61iAr8aTtFPmKpqxeBdLwmQ0ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@metaplex-foundation/umi-options": "^1.5.1",
+        "@metaplex-foundation/umi-public-keys": "^1.5.1",
+        "@metaplex-foundation/umi-serializers-core": "^1.5.1",
+        "@metaplex-foundation/umi-serializers-encodings": "^1.5.1",
+        "@metaplex-foundation/umi-serializers-numbers": "^1.5.1"
+      }
+    },
+    "node_modules/@metaplex-foundation/umi-serializers-core": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-serializers-core/-/umi-serializers-core-1.5.1.tgz",
+      "integrity": "sha512-6nYsbTCLq421x7JT1B3/iNgPpSARj/wL9naoKbOreHrk2ip/4R7vQstVRMl0Gx+Hv2tHnEIbFo3JBtWyC377Qw==",
+      "license": "MIT"
+    },
+    "node_modules/@metaplex-foundation/umi-serializers-encodings": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-serializers-encodings/-/umi-serializers-encodings-1.5.1.tgz",
+      "integrity": "sha512-cVvwWmREE/Pmvjvsd50F18P53HDT0vzZECD6uYWIVzxgwpOiRDFu6r/vGbweomHoWzfTvuU6hiKuKv2KsOoXQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@metaplex-foundation/umi-serializers-core": "^1.5.1"
+      }
+    },
+    "node_modules/@metaplex-foundation/umi-serializers-numbers": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-serializers-numbers/-/umi-serializers-numbers-1.5.1.tgz",
+      "integrity": "sha512-7DVF1VJIdT44Pe6qWKaqGu4YVgE10OeLMYpm7C16SujSBgQGB/I2bh8NBifyH2R3oHhoyfE9qgIKB3dgRazN6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@metaplex-foundation/umi-serializers-core": "^1.5.1"
+      }
+    },
+    "node_modules/@metaplex-foundation/umi-transaction-factory-web3js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-transaction-factory-web3js/-/umi-transaction-factory-web3js-1.5.1.tgz",
+      "integrity": "sha512-g4NfvtnmXtH1Q/Y9LdCsFtDRHQZmZWW7uKz+N9a+IVsJTTvpWFALMHm66dFDQGa0ExAYxAj7j6uZH2qDn0zarA==",
+      "license": "MIT",
+      "dependencies": {
+        "@metaplex-foundation/umi-web3js-adapters": "^1.5.1"
+      },
+      "peerDependencies": {
+        "@metaplex-foundation/umi": "^1.5.1",
+        "@solana/web3.js": "^1.72.0"
+      }
+    },
+    "node_modules/@metaplex-foundation/umi-web3js-adapters": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/umi-web3js-adapters/-/umi-web3js-adapters-1.5.1.tgz",
+      "integrity": "sha512-6W3JElD0B0EbgHofVKqk4PbP/JDrUHIKWciM7tEuXTDXbuXbSECDe7qlTU0JZXmVZNfYufI6FHnkCfPys2ZnIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@metaplex-foundation/umi": "^1.5.1",
+        "@solana/web3.js": "^1.72.0"
+      }
     },
     "node_modules/@modelcontextprotocol/server": {
       "version": "2.0.0-alpha.2",
@@ -181,6 +457,50 @@
       "os": [
         "linux"
       ]
+    },
+    "node_modules/@rollup/plugin-inject": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
+      "integrity": "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@scure/base": {
       "version": "1.2.6",
@@ -325,6 +645,21 @@
       },
       "engines": {
         "node": ">=5.10"
+      }
+    },
+    "node_modules/@solana/buffer-layout-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz",
+      "integrity": "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/web3.js": "^1.32.0",
+        "bigint-buffer": "^1.1.5",
+        "bignumber.js": "^9.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@solana/codecs": {
@@ -1049,6 +1384,277 @@
         }
       }
     },
+    "node_modules/@solana/spl-token": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.14.tgz",
+      "integrity": "sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/buffer-layout-utils": "^0.2.0",
+        "@solana/spl-token-group": "^0.0.7",
+        "@solana/spl-token-metadata": "^0.1.6",
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.5"
+      }
+    },
+    "node_modules/@solana/spl-token-group": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-group/-/spl-token-group-0.0.7.tgz",
+      "integrity": "sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-rc.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.3"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/options": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
+      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
+      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/options": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
+      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz",
+      "integrity": "sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-rc.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.3"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/options": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
+      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
+      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/options": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
+      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@solana/subscribable": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-5.5.1.tgz",
@@ -1186,6 +1792,7 @@
       "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz",
       "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "@noble/curves": "^1.4.2",
@@ -1269,6 +1876,25 @@
       "integrity": "sha512-JwWptdF5eOA0HaQxbKAzkpQtR4wSWTEfDlEy/y3/4okmOAX1qwnpLZMmtEWr+ncAhTTY1raCKH0kteHhSXnQqg==",
       "license": "MIT"
     },
+    "node_modules/@tributary-so/sdk": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@tributary-so/sdk/-/sdk-1.4.0.tgz",
+      "integrity": "sha512-n7I9D7OET4gCwcCyhVkgMJaWetePLsUACY5LofJEu8BWHk7vdSK8/Qj0dWqc5hjoWl8NbkFPdkF5xepdXvR2UA==",
+      "license": "MIT",
+      "dependencies": {
+        "@coral-xyz/anchor": "^0.31.0",
+        "@metaplex-foundation/mpl-token-metadata": "^3.4.0",
+        "@metaplex-foundation/umi": "^1.4.1",
+        "@metaplex-foundation/umi-bundle-defaults": "^1.4.1",
+        "@rollup/plugin-inject": "^5.0.5",
+        "@solana/spl-token": "^0.4.13",
+        "@solana/web3.js": "^1.98.4",
+        "bn.js": "^5.2.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -1277,6 +1903,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "12.20.55",
@@ -1407,6 +2039,37 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bigint-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
+      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bindings": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bn.js": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
@@ -1457,19 +2120,25 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/bufferutil": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
-      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-      "hasInstallScript": true,
+    "node_modules/buffer-layout": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/buffer-layout/-/buffer-layout-1.2.2.tgz",
+      "integrity": "sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
       "engines": {
-        "node": ">=6.14.2"
+        "node": ">=4.5"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/chalk": {
@@ -1491,6 +2160,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/delay": {
@@ -1520,6 +2198,12 @@
         "es6-promise": "^4.0.3"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -1538,6 +2222,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
       "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
+      "license": "MIT"
+    },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "license": "CC0-1.0",
+      "peer": true
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
     "node_modules/humanize-ms": {
@@ -1655,21 +2352,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -1696,6 +2378,15 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/mppx": {
       "version": "0.6.14",
@@ -1825,6 +2516,24 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/qrcode-terminal": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
@@ -1918,6 +2627,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/tokenx/-/tokenx-1.3.0.tgz",
       "integrity": "sha512-NLdXTEZkKiO0gZuLtMoZKjCXTREXeZZt8nnnNeyoXtNZAfG/GKGSbQtLU5STspc0rMSwcA+UJfWZkbNU01iKmQ==",
+      "license": "MIT"
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
       "license": "MIT"
     },
     "node_modules/tr46": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@open-wallet-standard/core": "^1.2.4",
     "@solana/web3.js": "^1.98.4",
-    "@tributary-so/sdk": "^1.11.1",
+    "@tributary-so/sdk": "^1.12.0",
     "@x402/evm": "^2.6.0",
     "@x402/fetch": "^2.6.0",
     "@x402/svm": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -56,9 +56,11 @@
   "dependencies": {
     "@open-wallet-standard/core": "^1.2.4",
     "@solana/web3.js": "^1.98.4",
+    "@tributary-so/sdk": "^1.11.1",
     "@x402/evm": "^2.6.0",
     "@x402/fetch": "^2.6.0",
     "@x402/svm": "^2.8.0",
+    "bn.js": "^5.2.2",
     "mppx": "^0.6.2",
     "qrcode-terminal": "^0.12.0",
     "viem": "^2.0.0"

--- a/skills/zerion-tributary/SKILL.md
+++ b/skills/zerion-tributary/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: zerion-tributary
+description: "Create and manage on-chain recurring subscriptions via Tributary protocol on Solana. Use when the user asks to set up recurring payments, subscriptions, pay-as-you-go policies, or view active payment policies. Requires a Zerion wallet with SOL and USDC on Solana. Pair with zerion-wallet for wallet setup and zerion-analyze for balance checks."
+license: MIT
+allowed-tools: Bash
+---
+
+# Zerion — Tributary Subscriptions
+
+Create and manage on-chain recurring payments on Solana via the Tributary protocol.
+
+## Setup
+
+```bash
+npm install -g zerion-cli
+```
+
+Requires Node.js >= 20. Wallet must have SOL for gas and USDC for payments on Solana.
+
+## When to use
+
+- "Set up a $10 monthly subscription to address X"
+- "Create recurring payment"
+- "Show my active subscriptions"
+- "Pause/resume/delete my subscription"
+- "List all payment policies"
+
+## Commands
+
+### Create subscription
+
+```bash
+zerion subscribe create <amount> <recipient> --interval <frequency> [flags]
+```
+
+- `amount` — human-readable USD amount (e.g., `10` = $10 USDC)
+- `recipient` — Solana pubkey receiving payments
+- `--interval` — required: `daily`, `weekly`, `monthly`, `quarterly`, `semi-annually`, `annually`
+- `--token` — token mint address (default: USDC)
+- `--gateway` — payment gateway PDA (default: Tributary gateway)
+- `--no-auto-renew` — disable auto-renewal
+- `--max-renewals` — cap number of renewals
+- `--memo` — memo string attached to the policy
+- `--wallet` — Zerion wallet name
+- `--dry-run` — build tx but don't send
+
+```bash
+zerion subscribe create 10 2NsnnHp9SaLzo... --interval monthly --wallet bot
+```
+
+### List subscriptions
+
+```bash
+zerion subscribe list [flags]
+```
+
+- `--status` — filter: `active`, `paused`, `all` (default: `all`)
+- `--pretty` — human-readable table output
+- `--wallet` — Zerion wallet name
+
+### Show single policy
+
+```bash
+zerion subscribe show <policy-id> [flags]
+```
+
+### Pause / Resume
+
+```bash
+zerion subscribe pause <policy-id> --token <mint> [--wallet <name>]
+zerion subscribe resume <policy-id> --token <mint> [--wallet <name>]
+```
+
+### Delete
+
+```bash
+zerion subscribe delete <policy-id> --token <mint> [--wallet <name>]
+```
+
+## Prerequisites
+
+1. A Zerion wallet with Solana account: `zerion wallet create --name bot`
+2. Fund with SOL + USDC on Solana: `zerion wallet fund --wallet bot`
+3. Agent token for signing: `zerion agent create-token --name bot-agent --wallet bot`
+
+## Demo flow
+
+```bash
+zerion subscribe create 10 <recipient> --interval monthly --wallet bot
+zerion subscribe list --wallet bot --pretty
+zerion subscribe show 1 --wallet bot
+zerion subscribe pause 1 --wallet bot
+zerion subscribe resume 1 --wallet bot
+```
+
+## Error codes
+
+| Code                 | Cause                                     |
+| -------------------- | ----------------------------------------- |
+| `missing_args`       | Required positional args or flags missing |
+| `invalid_amount`     | Amount is not a positive number           |
+| `invalid_interval`   | Unknown interval string                   |
+| `invalid_policy_id`  | Policy ID not a positive integer          |
+| `subscription_error` | SDK or on-chain error during create       |
+| `list_error`         | Failed to fetch policies                  |
+| `policy_not_found`   | Policy doesn't exist for this wallet      |


### PR DESCRIPTION
Integrates Tributary protocol for on-chain recurring subscriptions on Solana.

Adds 6 new CLI commands under zerion subscribe:
- create — create a recurring USDC payment to a recipient with configurable interval (daily through annually), auto-renew, max-renewals, and memo
- list — list all payment policies for a wallet, with status filtering and pretty table output
- show — display single policy details
- pause / resume — toggle policy status on-chain
- delete — permanently remove a policy

Supports all Tributary policy types (subscription, milestone, pay-as-you-go) for read operations. New dependencies: @tributary-so/sdk, bn.js. Includes SDK wrapper with local keystore signing, format helpers, and a zerion-tributary skill for agent discovery.