### PR TITLE
feat(cli): bridge provider selection, fee attribution, expanded chains list

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,10 +206,11 @@ Requires an API key (or agent token for unattended use).
 | `zerion swap <chain> <amount> <from-token> <to-token>` | Same-chain swap | `zerion swap base 1 USDC ETH` |
 | `zerion swap solana <amount> <from-token> <to-token>` | Solana same-chain swap | `zerion swap solana 0.1 SOL USDC` |
 | `zerion swap tokens [chain]` | List tokens available for swap | `zerion swap tokens solana` |
-| `zerion bridge <from-chain> <from-token> <amount> <to-chain> <to-token>` | Cross-chain bridge / bridge + swap | `zerion bridge base USDC 5 arbitrum USDC` |
-| `zerion bridge <from-chain> <from-token> <amount> <to-chain> <to-token> --to-token <tok>` | Bridge + token swap on destination | `zerion bridge base USDC 5 arbitrum ETH` |
-| `zerion bridge … --to-wallet <name>` | Bridge with explicit destination wallet (Solana ↔ EVM) | `zerion bridge ethereum USDC 5 solana USDC --to-wallet sol-bot` |
-| `zerion bridge … --to-address <addr>` | Bridge to a raw destination address | `zerion bridge ethereum USDC 5 solana USDC --to-address 8xLdox…` |
+| `zerion bridge <from-chain> <from-token> <amount> <to-chain> <to-token>` | List all bridge providers (no execute, multi-offer case) | `zerion bridge base USDC 5 arbitrum USDC` |
+| `zerion bridge … --cheapest` | Execute highest-output bridge route | `zerion bridge base USDC 5 arbitrum USDC --cheapest` |
+| `zerion bridge … --fast` | Execute lowest-time bridge route | `zerion bridge base USDC 5 arbitrum USDC --fast` |
+| `zerion bridge … --to-wallet <name>` | Bridge with explicit destination wallet (Solana ↔ EVM) | `zerion bridge ethereum USDC 5 solana USDC --to-wallet sol-bot --cheapest` |
+| `zerion bridge … --to-address <addr>` | Bridge to a raw destination address | `zerion bridge ethereum USDC 5 solana USDC --to-address 8xLdox… --cheapest` |
 | `zerion send <token> <amount> --to <address> [--chain <chain>]` | Send tokens (chain auto-detected from address format) | `zerion send usdc 50 --to 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --chain base` |
 | `zerion send SOL <amount> --to <solana-pubkey>` | Send native SOL on Solana | `zerion send SOL 0.1 --to 2Nsnn…` |
 

--- a/cli/commands/trading/bridge.js
+++ b/cli/commands/trading/bridge.js
@@ -1,5 +1,5 @@
-import { getSwapQuote, getSwapOffers, executeSwap } from "../../utils/trading/swap.js";
-import { requireAgentToken, parseTimeout, handleTradingError } from "../../utils/trading/guards.js";
+import { getSwapOffers, pickOffer, executeSwap } from "../../utils/trading/swap.js";
+import { requireAgentToken, parseTimeout, parseSlippage, handleTradingError } from "../../utils/trading/guards.js";
 import { resolveWallet, resolveDestination } from "../../utils/wallet/resolve.js";
 import { print, printError } from "../../utils/common/output.js";
 import { formatBridgeOffers } from "../../utils/common/format.js";
@@ -43,13 +43,37 @@ export default async function bridge(args, flags) {
     process.exit(1);
   }
 
-  if (flags.fast && flags.cheapest) {
+  // parseFlags treats any next non-`--` token as the flag value (so
+  // `--fast arbitrum` consumes "arbitrum" as the value), and the explicit
+  // `--no-fast` form yields `false`. Treat both `undefined` and `false` as
+  // "flag not set"; only reject string/number values that suggest the user
+  // meant to pass a value.
+  const isUnset = (v) => v === undefined || v === false;
+  const isStrictTrue = (v) => v === true;
+
+  if (!isUnset(flags.fast) && !isStrictTrue(flags.fast)) {
+    printError("invalid_flag_value", `--fast does not take a value (got "${flags.fast}"). Pass --fast on its own at the end of the command.`);
+    process.exit(1);
+  }
+  if (!isUnset(flags.cheapest) && !isStrictTrue(flags.cheapest)) {
+    printError("invalid_flag_value", `--cheapest does not take a value (got "${flags.cheapest}"). Pass --cheapest on its own at the end of the command.`);
+    process.exit(1);
+  }
+
+  const fastFlag = isStrictTrue(flags.fast);
+  const cheapestFlag = isStrictTrue(flags.cheapest);
+  if (fastFlag && cheapestFlag) {
     printError("conflicting_flags", "Pass either --fast or --cheapest, not both.", {
       suggestion: "Pick one strategy.",
     });
     process.exit(1);
   }
-  const strategy = flags.fast ? "fast" : flags.cheapest ? "cheapest" : null;
+  const strategy = fastFlag ? "fast" : cheapestFlag ? "cheapest" : null;
+
+  // Parse slippage up-front so a malformed value fails fast — before we hit
+  // the chain catalog API or resolve a wallet. Otherwise an invalid slippage
+  // surfaces only after a network round-trip.
+  const slippage = parseSlippage(flags.slippage);
 
   // Source wallet resolves against fromChain — Solana sources get base58, EVM sources get 0x.
   const { walletName, address } = resolveWallet({ ...flags, chain: fromChain });
@@ -78,7 +102,6 @@ export default async function bridge(args, flags) {
     process.exit(1);
   }
 
-  const slippage = flags.slippage ? parseFloat(flags.slippage) : undefined;
   const quoteInput = {
     fromToken,
     toToken,
@@ -90,46 +113,54 @@ export default async function bridge(args, flags) {
     slippage,
   };
 
-  // No strategy flag — list mode. Multi-offer responses surface every
-  // provider so the agent can pick. Single-offer responses fall through
-  // to execution since there is no choice to make.
-  if (!strategy) {
-    try {
-      const offers = await getSwapOffers(quoteInput);
-      if (offers.length > 1) {
-        const offerList = offers.map((q) => ({
-          provider: q.liquiditySource,
-          estimatedOutput: q.estimatedOutput,
-          estimatedSeconds: q.estimatedSeconds,
-          fee: q.fee,
-          executable: q.blocking == null,
-          blocking: q.blocking,
-        }));
-        print({
-          fromChain,
-          toChain,
-          fromToken,
-          toToken,
-          amount,
-          sender: address,
-          receiver,
-          offers: offerList,
-          count: offerList.length,
-          hint: "Re-run with --fast or --cheapest to execute. Use --cheapest for highest output, --fast for lowest time.",
-          executed: false,
-        }, formatBridgeOffers);
-        return;
-      }
-      // Single offer — fall through to execute below.
-    } catch (err) {
-      handleTradingError(err, "bridge_error");
+  // List and execute paths share the same `/swap/quotes/` fetch — picking
+  // from the offers array we just listed avoids a second round-trip that
+  // could return different routing, which closes the inspect-vs-execute
+  // race WITHIN a single invocation. Note: when the user runs `zerion
+  // bridge` (no flag) to list, then re-runs with `--cheapest`, that's two
+  // invocations, two API calls, and the second offer set may differ —
+  // downstream slippage tolerance / quote expiry / on-chain reverts bound
+  // execution risk in that flow, not this code.
+  let quote;
+  try {
+    const offers = await getSwapOffers(quoteInput);
+
+    if (!strategy && offers.length > 1) {
+      const offerList = offers.map((q) => ({
+        provider: q.liquiditySource,
+        estimatedOutput: q.estimatedOutput,
+        estimatedSeconds: q.estimatedSeconds,
+        fee: q.fee,
+        executable: q.blocking == null,
+        blocking: q.blocking,
+      }));
+      print({
+        fromChain,
+        toChain,
+        fromToken,
+        toToken,
+        amount,
+        sender: address,
+        receiver,
+        offers: offerList,
+        count: offerList.length,
+        hint: "Re-run with --fast or --cheapest to execute. Use --cheapest for highest output, --fast for lowest time.",
+        executed: false,
+      }, formatBridgeOffers);
       return;
     }
+
+    quote = pickOffer(offers, strategy || "cheapest");
+    if (!quote) {
+      printError("no_route", "No executable offer returned for this bridge.");
+      process.exit(1);
+    }
+  } catch (err) {
+    handleTradingError(err, "bridge_error");
+    return;
   }
 
   try {
-    const quote = await getSwapQuote({ ...quoteInput, strategy: strategy || "cheapest" });
-
     if (quote.preconditions.enough_balance === false) {
       printError("insufficient_funds", `Insufficient ${quote.from.symbol} balance`, {
         suggestion: `Fund your wallet: zerion wallet fund --wallet ${walletName}`,

--- a/cli/commands/trading/bridge.js
+++ b/cli/commands/trading/bridge.js
@@ -128,6 +128,34 @@ export default async function bridge(args, flags) {
   try {
     const offers = await getSwapOffers(quoteInput);
 
+    // If every offer is blocked (insufficient balance, output too small,
+    // etc.), there is nothing the user can pick — bail out with the most
+    // common blocking reason rather than printing a list of unactionable
+    // routes. Agents can still re-fetch with --raw or inspect via the JSON
+    // path; this handles the human-typed-it case cleanly.
+    const executableOffers = offers.filter(isQuoteExecutable);
+    if (executableOffers.length === 0) {
+      const blockingCodes = new Set(offers.map((o) => o.blocking?.code).filter(Boolean));
+      const allInsufficientBalance =
+        blockingCodes.size === 1 && blockingCodes.has("not_enough_input_asset_balance");
+      if (allInsufficientBalance) {
+        const sym = offers[0].from?.symbol || fromToken;
+        printError(
+          "insufficient_funds",
+          `Insufficient ${sym} balance on ${fromChain} to bridge ${amount} ${fromToken}.`,
+          {
+            wallet: walletName,
+            address,
+            suggestion: `Fund the wallet (\`zerion wallet fund --wallet ${walletName}\`) or try a smaller amount.`,
+          },
+        );
+        process.exit(1);
+      }
+      // Mixed blocking reasons or no blocking codes at all — list the
+      // offers anyway so the user can read why each route failed; the
+      // table's status column shows the reason per row.
+    }
+
     if (!strategy && offers.length > 1) {
       const offerList = offers.map((q) => ({
         provider: q.liquiditySource,

--- a/cli/commands/trading/bridge.js
+++ b/cli/commands/trading/bridge.js
@@ -1,12 +1,18 @@
-import { getSwapQuote, executeSwap } from "../../utils/trading/swap.js";
+import { getSwapQuote, getSwapOffers, executeSwap } from "../../utils/trading/swap.js";
 import { requireAgentToken, parseTimeout, handleTradingError } from "../../utils/trading/guards.js";
 import { resolveWallet, resolveDestination } from "../../utils/wallet/resolve.js";
 import { print, printError } from "../../utils/common/output.js";
+import { formatBridgeOffers } from "../../utils/common/format.js";
 import { validateTradingChainAsync } from "../../utils/common/validate.js";
 
 /**
  * Cross-chain bridge (with optional dest-token swap).
- * Usage: zerion bridge <from-chain> <from-token> <amount> <to-chain> <to-token>
+ * Usage: zerion bridge <from-chain> <from-token> <amount> <to-chain> <to-token> [--fast | --cheapest]
+ *
+ * Provider selection:
+ *   no flag  → list all offers and exit (multi-offer case); auto-execute single offer
+ *   --fast   → execute lowest `estimated_time_seconds`
+ *   --cheapest → execute highest net `output_amount` (matches API's default sort)
  *
  * For Solana ↔ EVM, pass --to-wallet or --to-address so the destination
  * receiver matches the dest chain's address format. Otherwise we use the
@@ -37,6 +43,14 @@ export default async function bridge(args, flags) {
     process.exit(1);
   }
 
+  if (flags.fast && flags.cheapest) {
+    printError("conflicting_flags", "Pass either --fast or --cheapest, not both.", {
+      suggestion: "Pick one strategy.",
+    });
+    process.exit(1);
+  }
+  const strategy = flags.fast ? "fast" : flags.cheapest ? "cheapest" : null;
+
   // Source wallet resolves against fromChain — Solana sources get base58, EVM sources get 0x.
   const { walletName, address } = resolveWallet({ ...flags, chain: fromChain });
 
@@ -64,17 +78,57 @@ export default async function bridge(args, flags) {
     process.exit(1);
   }
 
+  const slippage = flags.slippage ? parseFloat(flags.slippage) : undefined;
+  const quoteInput = {
+    fromToken,
+    toToken,
+    amount,
+    fromChain,
+    toChain,
+    walletAddress: address,
+    outputReceiver: receiver,
+    slippage,
+  };
+
+  // No strategy flag — list mode. Multi-offer responses surface every
+  // provider so the agent can pick. Single-offer responses fall through
+  // to execution since there is no choice to make.
+  if (!strategy) {
+    try {
+      const offers = await getSwapOffers(quoteInput);
+      if (offers.length > 1) {
+        const offerList = offers.map((q) => ({
+          provider: q.liquiditySource,
+          estimatedOutput: q.estimatedOutput,
+          estimatedSeconds: q.estimatedSeconds,
+          fee: q.fee,
+          executable: q.blocking == null,
+          blocking: q.blocking,
+        }));
+        print({
+          fromChain,
+          toChain,
+          fromToken,
+          toToken,
+          amount,
+          sender: address,
+          receiver,
+          offers: offerList,
+          count: offerList.length,
+          hint: "Re-run with --fast or --cheapest to execute. Use --cheapest for highest output, --fast for lowest time.",
+          executed: false,
+        }, formatBridgeOffers);
+        return;
+      }
+      // Single offer — fall through to execute below.
+    } catch (err) {
+      handleTradingError(err, "bridge_error");
+      return;
+    }
+  }
+
   try {
-    const quote = await getSwapQuote({
-      fromToken,
-      toToken,
-      amount,
-      fromChain,
-      toChain,
-      walletAddress: address,
-      outputReceiver: receiver,
-      slippage: flags.slippage ? parseFloat(flags.slippage) : undefined,
-    });
+    const quote = await getSwapQuote({ ...quoteInput, strategy: strategy || "cheapest" });
 
     if (quote.preconditions.enough_balance === false) {
       printError("insufficient_funds", `Insufficient ${quote.from.symbol} balance`, {
@@ -97,6 +151,7 @@ export default async function bridge(args, flags) {
         fee: quote.fee,
         source: quote.liquiditySource,
         estimatedTime: `${quote.estimatedSeconds || "?"}s`,
+        strategy: strategy || "cheapest",
       },
     };
 

--- a/cli/commands/trading/bridge.js
+++ b/cli/commands/trading/bridge.js
@@ -1,4 +1,4 @@
-import { getSwapOffers, pickOffer, executeSwap } from "../../utils/trading/swap.js";
+import { getSwapOffers, pickOffer, isQuoteExecutable, executeSwap } from "../../utils/trading/swap.js";
 import { requireAgentToken, parseTimeout, parseSlippage, handleTradingError } from "../../utils/trading/guards.js";
 import { resolveWallet, resolveDestination } from "../../utils/wallet/resolve.js";
 import { print, printError } from "../../utils/common/output.js";
@@ -44,24 +44,27 @@ export default async function bridge(args, flags) {
   }
 
   // parseFlags treats any next non-`--` token as the flag value (so
-  // `--fast arbitrum` consumes "arbitrum" as the value), and the explicit
-  // `--no-fast` form yields `false`. Treat both `undefined` and `false` as
-  // "flag not set"; only reject string/number values that suggest the user
-  // meant to pass a value.
-  const isUnset = (v) => v === undefined || v === false;
-  const isStrictTrue = (v) => v === true;
-
-  if (!isUnset(flags.fast) && !isStrictTrue(flags.fast)) {
-    printError("invalid_flag_value", `--fast does not take a value (got "${flags.fast}"). Pass --fast on its own at the end of the command.`);
+  // `--fast arbitrum` consumes "arbitrum" as the value), the `--key=value`
+  // form preserves the value as a string, and `--no-fast` yields `false`.
+  // We want all of these to behave naturally:
+  //   --fast            (true)        → enabled
+  //   --fast=true       ("true")      → enabled
+  //   --fast=false      ("false")     → disabled (unset)
+  //   --no-fast         (false)       → disabled (unset)
+  //   --fast arbitrum   ("arbitrum")  → REJECT (positional consumed)
+  function coerceBoolFlag(value, name) {
+    if (value === undefined) return false;
+    if (value === true || value === "true") return true;
+    if (value === false || value === "false") return false;
+    printError(
+      "invalid_flag_value",
+      `--${name} does not take a value (got "${value}"). Pass --${name} on its own at the end of the command, or use --${name}=true / --no-${name}.`,
+    );
     process.exit(1);
   }
-  if (!isUnset(flags.cheapest) && !isStrictTrue(flags.cheapest)) {
-    printError("invalid_flag_value", `--cheapest does not take a value (got "${flags.cheapest}"). Pass --cheapest on its own at the end of the command.`);
-    process.exit(1);
-  }
 
-  const fastFlag = isStrictTrue(flags.fast);
-  const cheapestFlag = isStrictTrue(flags.cheapest);
+  const fastFlag = coerceBoolFlag(flags.fast, "fast");
+  const cheapestFlag = coerceBoolFlag(flags.cheapest, "cheapest");
   if (fastFlag && cheapestFlag) {
     printError("conflicting_flags", "Pass either --fast or --cheapest, not both.", {
       suggestion: "Pick one strategy.",
@@ -131,7 +134,10 @@ export default async function bridge(args, flags) {
         estimatedOutput: q.estimatedOutput,
         estimatedSeconds: q.estimatedSeconds,
         fee: q.fee,
-        executable: q.blocking == null,
+        // Match pickOffer's selection logic — an offer with no blocking
+        // error but missing transaction data would otherwise show as
+        // `ready` here and get silently skipped at execution.
+        executable: isQuoteExecutable(q),
         blocking: q.blocking,
       }));
       print({

--- a/cli/commands/trading/swap.js
+++ b/cli/commands/trading/swap.js
@@ -1,5 +1,5 @@
 import { getSwapQuote, executeSwap } from "../../utils/trading/swap.js";
-import { requireAgentToken, parseTimeout, handleTradingError } from "../../utils/trading/guards.js";
+import { requireAgentToken, parseTimeout, parseSlippage, handleTradingError } from "../../utils/trading/guards.js";
 import { resolveWallet } from "../../utils/wallet/resolve.js";
 import { print, printError } from "../../utils/common/output.js";
 import { formatSwapQuote } from "../../utils/common/format.js";
@@ -49,7 +49,7 @@ export default async function swap(args, flags) {
       toChain: chain,
       walletAddress: address,
       outputReceiver: address,
-      slippage: flags.slippage ? parseFloat(flags.slippage) : undefined,
+      slippage: parseSlippage(flags.slippage),
     });
 
     if (quote.preconditions.enough_balance === false) {

--- a/cli/router.js
+++ b/cli/router.js
@@ -129,10 +129,17 @@ function printUsage() {
       "init -y --browser": "Non-interactive init that opens dashboard.zerion.io for the API key",
       "setup skills": "Install Zerion agent skills via `npx skills add zeriontech/zerion-ai` (45+ hosts)",
     },
+    // Trading-supported chains (swap/bridge/send). Mirrors Zerion API
+    // /chains/ flags.supports_trading=true at time of release. For the live
+    // list, run `zerion chains` — that hits the API and is always current.
     chains: [
-      "ethereum", "base", "arbitrum", "optimism", "polygon",
-      "binance-smart-chain", "avalanche", "gnosis", "scroll",
-      "linea", "zksync-era", "zora", "blast", "solana"
+      "abstract", "ape", "arbitrum", "avalanche", "base", "berachain",
+      "binance-smart-chain", "blast", "bob", "celo", "cyber", "ethereum",
+      "fraxtal", "hyperevm", "ink", "katana", "lens", "linea", "lisk",
+      "manta-pacific", "mantle", "megaeth", "metis-andromeda", "mode",
+      "monad", "opbnb", "optimism", "plasma", "polygon", "rari", "ronin",
+      "scroll", "sei", "solana", "soneium", "sonic", "swellchain", "taiko",
+      "tomochain", "unichain", "world", "xdai", "zero", "zksync-era", "zora",
     ],
   };
   process.stdout.write(JSON.stringify(usage, null, 2) + "\n");

--- a/cli/tests/unit/cli/commands/trading/bridge.test.mjs
+++ b/cli/tests/unit/cli/commands/trading/bridge.test.mjs
@@ -1,0 +1,152 @@
+// Bridge command — flag validation and early-exit paths.
+//
+// These tests exec the CLI as a subprocess so the in-process monkey-patching
+// of `process.stdout.write` (needed to capture printError output) doesn't
+// interfere with node:test's own reporter. We assert exit code + parsed JSON
+// error from stderr — the same surface agent integrations rely on.
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "..", "..", "..", "..", "..", "..");
+const CLI_PATH = join(REPO_ROOT, "cli", "zerion.js");
+
+function runBridge(args, env = {}) {
+  const result = spawnSync(
+    process.execPath,
+    [CLI_PATH, "bridge", ...args],
+    {
+      env: { ...process.env, ZERION_API_KEY: "zk_unit_test", ...env },
+      encoding: "utf-8",
+      timeout: 5000,
+    },
+  );
+  return {
+    exitCode: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function parseError(stderr) {
+  if (!stderr) return null;
+  try {
+    return JSON.parse(stderr).error;
+  } catch {
+    return null;
+  }
+}
+
+describe("bridge — early-exit validation", () => {
+  it("rejects missing args with a usage message", () => {
+    const { exitCode, stderr } = runBridge([]);
+    assert.equal(exitCode, 1);
+    assert.equal(parseError(stderr).code, "missing_args");
+  });
+
+  it("rejects non-numeric amount", () => {
+    const { exitCode, stderr } = runBridge(["base", "USDC", "abc", "arbitrum", "USDC"]);
+    assert.equal(exitCode, 1);
+    assert.equal(parseError(stderr).code, "invalid_amount");
+  });
+
+  it("rejects same-chain bridge with a swap suggestion", () => {
+    const { exitCode, stderr } = runBridge(["base", "USDC", "5", "base", "USDC"]);
+    assert.equal(exitCode, 1);
+    const err = parseError(stderr);
+    assert.equal(err.code, "same_chain_bridge");
+    assert.match(err.example, /^zerion swap base/);
+  });
+
+  it("rejects --fast with a string value (parseFlags consumed a positional)", () => {
+    // `bridge base USDC 5 arbitrum USDC --fast=false` → flags.fast = "false"
+    const { exitCode, stderr } = runBridge([
+      "base", "USDC", "5", "arbitrum", "USDC", "--fast=false",
+    ]);
+    assert.equal(exitCode, 1);
+    const err = parseError(stderr);
+    assert.equal(err.code, "invalid_flag_value");
+    assert.match(err.message, /--fast does not take a value/);
+  });
+
+  it("rejects --cheapest with a string value", () => {
+    const { exitCode, stderr } = runBridge([
+      "base", "USDC", "5", "arbitrum", "USDC", "--cheapest=anything",
+    ]);
+    assert.equal(exitCode, 1);
+    assert.equal(parseError(stderr).code, "invalid_flag_value");
+  });
+
+  it("rejects mid-position --fast (parseFlags consumed a positional arg)", () => {
+    // `bridge --fast base USDC 5 arbitrum USDC` — parseFlags consumes "base"
+    // as the value of --fast, leaving rest=[USDC, 5, arbitrum, USDC] (only 4
+    // positional args). Either error is acceptable: missing_args (the args
+    // check fires first because parseFlags ate "base") or invalid_flag_value
+    // (if the validator runs first). What matters is the user gets a non-zero
+    // exit and not a silent fast-mode execution with mangled chain args.
+    const { exitCode, stderr } = runBridge([
+      "--fast", "base", "USDC", "5", "arbitrum", "USDC",
+    ]);
+    assert.equal(exitCode, 1);
+    const code = parseError(stderr)?.code;
+    assert.ok(
+      code === "missing_args" || code === "invalid_flag_value",
+      `expected missing_args or invalid_flag_value, got ${code}`,
+    );
+  });
+
+  it("rejects --fast and --cheapest passed together", () => {
+    const { exitCode, stderr } = runBridge([
+      "base", "USDC", "5", "arbitrum", "USDC", "--fast", "--cheapest",
+    ]);
+    assert.equal(exitCode, 1);
+    assert.equal(parseError(stderr).code, "conflicting_flags");
+  });
+
+  it("rejects invalid slippage values", () => {
+    for (const bad of ["abc", "-5", "200"]) {
+      const { exitCode, stderr } = runBridge([
+        "base", "USDC", "5", "arbitrum", "USDC", `--slippage=${bad}`, "--cheapest",
+      ]);
+      assert.equal(exitCode, 1, `expected exit on slippage="${bad}"`);
+      assert.equal(
+        parseError(stderr).code,
+        "invalid_slippage",
+        `wrong code for slippage="${bad}"`,
+      );
+    }
+  });
+
+  it("treats --no-fast as unset, NOT as a string-valued flag", () => {
+    // parseFlags assigns `flags.fast = false` for the explicit-disable form.
+    // Bridge should not raise invalid_flag_value — the user explicitly asked
+    // to turn the flag off, semantically equivalent to not passing it.
+    // Downstream errors (no wallet, no API mock) are acceptable; we only
+    // care that the flag validator didn't reject the disabled form.
+    const { stderr } = runBridge([
+      "base", "USDC", "5", "arbitrum", "USDC", "--no-fast",
+    ]);
+    const err = parseError(stderr);
+    if (err) {
+      assert.notEqual(
+        err.code,
+        "invalid_flag_value",
+        "flag validator should accept --no-fast (false) as unset",
+      );
+    }
+  });
+
+  it("treats --no-cheapest as unset, NOT as a string-valued flag", () => {
+    const { stderr } = runBridge([
+      "base", "USDC", "5", "arbitrum", "USDC", "--no-cheapest",
+    ]);
+    const err = parseError(stderr);
+    if (err) {
+      assert.notEqual(err.code, "invalid_flag_value");
+    }
+  });
+});

--- a/cli/tests/unit/cli/commands/trading/bridge.test.mjs
+++ b/cli/tests/unit/cli/commands/trading/bridge.test.mjs
@@ -62,10 +62,10 @@ describe("bridge — early-exit validation", () => {
     assert.match(err.example, /^zerion swap base/);
   });
 
-  it("rejects --fast with a string value (parseFlags consumed a positional)", () => {
-    // `bridge base USDC 5 arbitrum USDC --fast=false` → flags.fast = "false"
+  it("rejects --fast with a non-boolean string value", () => {
+    // `--fast=anything` is a real value; only "true"/"false" are accepted.
     const { exitCode, stderr } = runBridge([
-      "base", "USDC", "5", "arbitrum", "USDC", "--fast=false",
+      "base", "USDC", "5", "arbitrum", "USDC", "--fast=cheapest",
     ]);
     assert.equal(exitCode, 1);
     const err = parseError(stderr);
@@ -73,7 +73,25 @@ describe("bridge — early-exit validation", () => {
     assert.match(err.message, /--fast does not take a value/);
   });
 
-  it("rejects --cheapest with a string value", () => {
+  it("accepts --fast=true and --fast=false", () => {
+    // Both forms are valid bool-flag conventions. `--fast=false` should
+    // behave like the flag is unset, not like an error.
+    for (const form of ["--fast=true", "--fast=false"]) {
+      const { stderr } = runBridge([
+        "base", "USDC", "5", "arbitrum", "USDC", form,
+      ]);
+      const err = parseError(stderr);
+      if (err) {
+        assert.notEqual(
+          err.code,
+          "invalid_flag_value",
+          `${form} should be accepted as a boolean form`,
+        );
+      }
+    }
+  });
+
+  it("rejects --cheapest with a non-boolean string value", () => {
     const { exitCode, stderr } = runBridge([
       "base", "USDC", "5", "arbitrum", "USDC", "--cheapest=anything",
     ]);
@@ -108,7 +126,7 @@ describe("bridge — early-exit validation", () => {
   });
 
   it("rejects invalid slippage values", () => {
-    for (const bad of ["abc", "-5", "200"]) {
+    for (const bad of ["abc", "-5", "200", "2abc", "2.5xyz", " "]) {
       const { exitCode, stderr } = runBridge([
         "base", "USDC", "5", "arbitrum", "USDC", `--slippage=${bad}`, "--cheapest",
       ]);

--- a/cli/tests/unit/cli/utils/api/client.test.mjs
+++ b/cli/tests/unit/cli/utils/api/client.test.mjs
@@ -33,7 +33,9 @@ describe("fetchAPI — User-Agent header", () => {
 
     const ua = capturedHeaders["User-Agent"];
     assert.ok(ua, "User-Agent header was not sent");
-    assert.match(ua, /^zerion-cli(\/\d+\.\d+\.\d+(-\S+)?)?$/, `unexpected UA: ${ua}`);
+    // Strict version check — bare `zerion-cli` is the package.json-missing
+    // fallback and would mean fee attribution by version is broken.
+    assert.match(ua, /^zerion-cli\/\d+\.\d+\.\d+(-\S+)?$/, `unexpected UA: ${ua}`);
   });
 
   it("sends Accept and Authorization alongside User-Agent", async () => {
@@ -48,5 +50,24 @@ describe("fetchAPI — User-Agent header", () => {
     assert.equal(capturedHeaders.Accept, "application/json");
     assert.ok(capturedHeaders.Authorization?.startsWith("Basic "));
     assert.ok(capturedHeaders["User-Agent"]);
+  });
+
+  // x402 and MPP wrap `fetch` and forward `(url, options)` unchanged. The
+  // headers we set in fetchAPI must reach the underlying fetch the wrapper
+  // calls. Here we mock the wrapper at its lowest layer (globalThis.fetch
+  // — both wrappers ultimately call it) and assert the UA propagates.
+  it("propagates User-Agent through fetch wrapper layers", async () => {
+    let capturedHeaders;
+    globalThis.fetch = async (_url, opts) => {
+      capturedHeaders = opts?.headers || {};
+      return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+    };
+
+    await fetchAPI("/chains/");
+
+    assert.ok(
+      capturedHeaders["User-Agent"]?.startsWith("zerion-cli"),
+      "User-Agent must reach the underlying fetch even when wrappers are in play"
+    );
   });
 });

--- a/cli/tests/unit/cli/utils/api/client.test.mjs
+++ b/cli/tests/unit/cli/utils/api/client.test.mjs
@@ -1,0 +1,52 @@
+// Verifies that fetchAPI tags every request with the `User-Agent: zerion-cli/<version>`
+// header so backend telemetry can attribute API calls to the agent CLI.
+
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { fetchAPI } from "#zerion/utils/api/client.js";
+
+const originalFetch = globalThis.fetch;
+const originalApiKey = process.env.ZERION_API_KEY;
+
+beforeEach(() => {
+  process.env.ZERION_API_KEY = "zk_unit_test";
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalApiKey === undefined) delete process.env.ZERION_API_KEY;
+  else process.env.ZERION_API_KEY = originalApiKey;
+});
+
+describe("fetchAPI — User-Agent header", () => {
+  it("sets User-Agent to zerion-cli/<version> on every request", async () => {
+    let capturedHeaders;
+    globalThis.fetch = async (_url, opts) => {
+      capturedHeaders = opts?.headers || {};
+      return new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    await fetchAPI("/chains/");
+
+    const ua = capturedHeaders["User-Agent"];
+    assert.ok(ua, "User-Agent header was not sent");
+    assert.match(ua, /^zerion-cli(\/\d+\.\d+\.\d+(-\S+)?)?$/, `unexpected UA: ${ua}`);
+  });
+
+  it("sends Accept and Authorization alongside User-Agent", async () => {
+    let capturedHeaders;
+    globalThis.fetch = async (_url, opts) => {
+      capturedHeaders = opts?.headers || {};
+      return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+    };
+
+    await fetchAPI("/chains/");
+
+    assert.equal(capturedHeaders.Accept, "application/json");
+    assert.ok(capturedHeaders.Authorization?.startsWith("Basic "));
+    assert.ok(capturedHeaders["User-Agent"]);
+  });
+});

--- a/cli/tests/unit/cli/utils/common/format.test.mjs
+++ b/cli/tests/unit/cli/utils/common/format.test.mjs
@@ -1,0 +1,131 @@
+// formatBridgeOffers — pretty-print formatter for `zerion bridge` list mode.
+// Renders offer table to stdout when --pretty is on. The agent flow uses the
+// JSON output in bridge.js; this formatter is the human-facing shape.
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { formatBridgeOffers } from "#zerion/utils/common/format.js";
+
+const SAMPLE = {
+  fromChain: "base",
+  toChain: "arbitrum",
+  fromToken: "USDC",
+  toToken: "USDC",
+  amount: "5",
+  offers: [
+    {
+      provider: "stargate-v2",
+      estimatedOutput: "4.99",
+      estimatedSeconds: 30,
+      fee: { protocolPercent: 0.3 },
+      executable: true,
+    },
+    {
+      provider: "across",
+      estimatedOutput: "4.97",
+      estimatedSeconds: 8,
+      fee: { protocolPercent: 0.5 },
+      executable: true,
+    },
+  ],
+  count: 2,
+};
+
+describe("formatBridgeOffers", () => {
+  it("renders header with chain pair and amount", () => {
+    const out = formatBridgeOffers(SAMPLE);
+    assert.match(out, /Bridge Quotes/);
+    assert.match(out, /base → arbitrum/);
+    assert.match(out, /5 USDC → USDC/);
+  });
+
+  it("includes a row per offer with provider, output, time, fee", () => {
+    const out = formatBridgeOffers(SAMPLE);
+    assert.match(out, /stargate-v2/);
+    assert.match(out, /across/);
+    assert.match(out, /4\.99/);
+    assert.match(out, /4\.97/);
+    assert.match(out, /30s/);
+    assert.match(out, /8s/);
+    assert.match(out, /0\.30%/);
+    assert.match(out, /0\.50%/);
+  });
+
+  it("shows '-' for missing estimatedSeconds, fee, output", () => {
+    const out = formatBridgeOffers({
+      ...SAMPLE,
+      offers: [{
+        provider: "minimal-router",
+        estimatedOutput: null,
+        estimatedSeconds: null,
+        fee: {},
+        executable: true,
+      }],
+      count: 1,
+    });
+    // Three '-' entries (output, time, fee) — match across the row.
+    assert.match(out, /minimal-router/);
+    const dashCount = (out.match(/ - /g) || []).length;
+    assert.ok(dashCount >= 2, `expected >=2 dashes for missing fields, got ${dashCount} in:\n${out}`);
+  });
+
+  it("truncates long provider names so columns don't drift", () => {
+    const out = formatBridgeOffers({
+      ...SAMPLE,
+      offers: [{
+        provider: "a-very-long-provider-name-that-exceeds-column-width",
+        estimatedOutput: "100",
+        estimatedSeconds: 10,
+        fee: { protocolPercent: 0 },
+        executable: true,
+      }],
+      count: 1,
+    });
+    // Truncated form should NOT contain the full string verbatim.
+    assert.doesNotMatch(out, /a-very-long-provider-name-that-exceeds-column-width/);
+    // But the prefix should still be there.
+    assert.match(out, /a-very-long/);
+  });
+
+  it("marks blocked offers visually so users see what pickOffer skips", () => {
+    const out = formatBridgeOffers({
+      ...SAMPLE,
+      offers: [
+        {
+          provider: "blocked-router",
+          estimatedOutput: "999",
+          estimatedSeconds: 5,
+          fee: { protocolPercent: 0 },
+          executable: false,
+          blocking: { code: "not_enough_input_asset_balance" },
+        },
+        {
+          provider: "ok-router",
+          estimatedOutput: "100",
+          estimatedSeconds: 30,
+          fee: { protocolPercent: 0.3 },
+          executable: true,
+        },
+      ],
+      count: 2,
+    });
+    assert.match(out, /blocked/, "blocked status label missing");
+    assert.match(out, /ready/, "ready status label missing");
+  });
+
+  it("includes the --cheapest / --fast hint", () => {
+    const out = formatBridgeOffers(SAMPLE);
+    assert.match(out, /--cheapest/);
+    assert.match(out, /--fast/);
+  });
+
+  it("does not crash on an empty offers array", () => {
+    const out = formatBridgeOffers({
+      ...SAMPLE,
+      offers: [],
+      count: 0,
+    });
+    assert.match(out, /Bridge Quotes/);
+    assert.match(out, /no offers/);
+  });
+});

--- a/cli/tests/unit/cli/utils/trading/swap.test.mjs
+++ b/cli/tests/unit/cli/utils/trading/swap.test.mjs
@@ -300,7 +300,26 @@ describe("getSwapQuote — /swap/quotes/ migration", () => {
 
     // Cross-check with pickOffer: the same predicate drives selection.
     const picked = pickOffer([noTxQuote, evmQuote], "cheapest");
-    assert.notEqual(picked, noTxQuote, "pickOffer must skip no-tx quote even when blocking is null");
+    assert.equal(picked, evmQuote, "pickOffer must skip no-tx quote even when blocking is null");
+  });
+
+  it("pickOffer returns null when no quotes are executable AND none carry blocking errors", () => {
+    // No-tx + no-error means there is nothing signable AND nothing
+    // actionable. Treat as routing failure (caller surfaces no_route).
+    const quotes = [
+      { blocking: null, transactionSwap: null, estimatedOutput: "100" },
+      { blocking: null, transactionSwap: null, estimatedOutput: "120" },
+    ];
+    assert.equal(pickOffer(quotes, "cheapest"), null);
+  });
+
+  it("pickOffer returns the best blocked-with-error quote when nothing is executable (so executeSwap can surface the API error)", () => {
+    const quotes = [
+      { id: "small", blocking: { code: "minimum_input_amount" }, transactionSwap: null, estimatedOutput: "10" },
+      { id: "big",   blocking: { code: "minimum_input_amount" }, transactionSwap: null, estimatedOutput: "999" },
+    ];
+    const picked = pickOffer(quotes, "cheapest");
+    assert.equal(picked.id, "big");
   });
 
   it("getSwapOffers throws no_route when API returns empty data", async () => {

--- a/cli/tests/unit/cli/utils/trading/swap.test.mjs
+++ b/cli/tests/unit/cli/utils/trading/swap.test.mjs
@@ -5,7 +5,7 @@
 
 import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, it } from "node:test";
-import { getSwapQuote } from "#zerion/utils/trading/swap.js";
+import { getSwapQuote, getSwapOffers, selectOffer } from "#zerion/utils/trading/swap.js";
 
 const originalFetch = globalThis.fetch;
 const originalApiKey = process.env.ZERION_API_KEY;
@@ -180,6 +180,124 @@ describe("getSwapQuote — /swap/quotes/ migration", () => {
     assert.ok(quote.transactionSwap);
     assert.equal(quote.transactionSwap.to, "0xRouter");
     assert.equal(quote.transactionApprove, null);
+  });
+
+  it("selectOffer 'cheapest' picks the offer with the highest output amount", () => {
+    const offers = [
+      { id: "a", attributes: { output_amount: { quantity: "100" }, estimated_time_seconds: 30, transaction_swap: { evm: {} } } },
+      { id: "b", attributes: { output_amount: { quantity: "120" }, estimated_time_seconds: 60, transaction_swap: { evm: {} } } },
+      { id: "c", attributes: { output_amount: { quantity: "110" }, estimated_time_seconds: 15, transaction_swap: { evm: {} } } },
+    ];
+    const picked = selectOffer(offers, "cheapest");
+    assert.equal(picked.id, "b");
+  });
+
+  it("selectOffer 'fast' picks the offer with the lowest estimated_time_seconds", () => {
+    const offers = [
+      { id: "a", attributes: { output_amount: { quantity: "100" }, estimated_time_seconds: 30, transaction_swap: { evm: {} } } },
+      { id: "b", attributes: { output_amount: { quantity: "120" }, estimated_time_seconds: 60, transaction_swap: { evm: {} } } },
+      { id: "c", attributes: { output_amount: { quantity: "110" }, estimated_time_seconds: 15, transaction_swap: { evm: {} } } },
+    ];
+    const picked = selectOffer(offers, "fast");
+    assert.equal(picked.id, "c");
+  });
+
+  it("selectOffer 'fast' falls back to cheapest when no offer carries time data", () => {
+    const offers = [
+      { id: "a", attributes: { output_amount: { quantity: "100" }, transaction_swap: { evm: {} } } },
+      { id: "b", attributes: { output_amount: { quantity: "120" }, transaction_swap: { evm: {} } } },
+    ];
+    const picked = selectOffer(offers, "fast");
+    assert.equal(picked.id, "b");
+  });
+
+  it("selectOffer prefers executable offers over blocked ones", () => {
+    const offers = [
+      { id: "blocked", attributes: { output_amount: { quantity: "999" }, error: { code: "not_enough_input_asset_balance" } } },
+      { id: "ok", attributes: { output_amount: { quantity: "100" }, estimated_time_seconds: 30, transaction_swap: { evm: {} } } },
+    ];
+    const picked = selectOffer(offers, "cheapest");
+    assert.equal(picked.id, "ok");
+  });
+
+  it("selectOffer returns the only blocked offer when no executable one exists (so caller can surface error)", () => {
+    const offers = [
+      { id: "blocked", attributes: { output_amount: { quantity: "100" }, error: { code: "not_enough_input_asset_balance" } } },
+    ];
+    const picked = selectOffer(offers, "cheapest");
+    assert.equal(picked.id, "blocked");
+  });
+
+  it("selectOffer returns null for empty offers", () => {
+    assert.equal(selectOffer([], "cheapest"), null);
+  });
+
+  it("getSwapOffers returns every API offer mapped to the quote shape", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({
+        data: [
+          { id: "fast-route", type: "swap_quotes", attributes: {
+            liquidity_source: { name: "fast-router" },
+            output_amount: { quantity: "98" },
+            estimated_time_seconds: 10,
+            transaction_swap: { evm: { to: "0xRouter1" } },
+          }},
+          { id: "cheap-route", type: "swap_quotes", attributes: {
+            liquidity_source: { name: "cheap-router" },
+            output_amount: { quantity: "100" },
+            estimated_time_seconds: 90,
+            transaction_swap: { evm: { to: "0xRouter2" } },
+          }},
+        ],
+      }), { status: 200, headers: { "content-type": "application/json" } });
+
+    const offers = await getSwapOffers({
+      fromToken: "ETH",
+      toToken: "USDC",
+      amount: "0.1",
+      fromChain: "ethereum",
+      toChain: "ethereum",
+      walletAddress: "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B",
+    });
+
+    assert.equal(offers.length, 2);
+    assert.equal(offers[0].liquiditySource, "fast-router");
+    assert.equal(offers[0].estimatedSeconds, 10);
+    assert.equal(offers[1].liquiditySource, "cheap-router");
+    assert.equal(offers[1].estimatedOutput, "100");
+  });
+
+  it("getSwapQuote with strategy='fast' picks the lowest-time offer", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({
+        data: [
+          { id: "slow", type: "swap_quotes", attributes: {
+            liquidity_source: { name: "slow-but-cheap" },
+            output_amount: { quantity: "120" },
+            estimated_time_seconds: 120,
+            transaction_swap: { evm: { to: "0xSlow" } },
+          }},
+          { id: "fast", type: "swap_quotes", attributes: {
+            liquidity_source: { name: "fast-but-pricey" },
+            output_amount: { quantity: "100" },
+            estimated_time_seconds: 8,
+            transaction_swap: { evm: { to: "0xFast" } },
+          }},
+        ],
+      }), { status: 200, headers: { "content-type": "application/json" } });
+
+    const quote = await getSwapQuote({
+      fromToken: "ETH",
+      toToken: "USDC",
+      amount: "0.1",
+      fromChain: "ethereum",
+      toChain: "ethereum",
+      walletAddress: "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B",
+      strategy: "fast",
+    });
+
+    assert.equal(quote.liquiditySource, "fast-but-pricey");
+    assert.equal(quote.estimatedSeconds, 8);
   });
 
   it("surfaces blocking errors and marks balance insufficient", async () => {

--- a/cli/tests/unit/cli/utils/trading/swap.test.mjs
+++ b/cli/tests/unit/cli/utils/trading/swap.test.mjs
@@ -5,7 +5,7 @@
 
 import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, it } from "node:test";
-import { getSwapQuote, getSwapOffers, selectOffer } from "#zerion/utils/trading/swap.js";
+import { getSwapQuote, getSwapOffers, selectOffer, pickOffer } from "#zerion/utils/trading/swap.js";
 
 const originalFetch = globalThis.fetch;
 const originalApiKey = process.env.ZERION_API_KEY;
@@ -230,6 +230,86 @@ describe("getSwapQuote — /swap/quotes/ migration", () => {
 
   it("selectOffer returns null for empty offers", () => {
     assert.equal(selectOffer([], "cheapest"), null);
+  });
+
+  it("selectOffer ignores non-finite output_amount when picking cheapest (NaN/missing don't anchor reducer)", () => {
+    const offers = [
+      // Malformed first offer must NOT win.
+      { id: "broken", attributes: { output_amount: { quantity: "NaN" }, transaction_swap: { evm: {} } } },
+      { id: "missing", attributes: { transaction_swap: { evm: {} } } },
+      { id: "real", attributes: { output_amount: { quantity: "100" }, transaction_swap: { evm: {} } } },
+    ];
+    const picked = selectOffer(offers, "cheapest");
+    assert.equal(picked.id, "real");
+  });
+
+  it("pickOffer (mapped-quote selector) picks max estimatedOutput for 'cheapest'", () => {
+    const quotes = [
+      { id: "a", estimatedOutput: "100", estimatedSeconds: 30, blocking: null, transactionSwap: {} },
+      { id: "b", estimatedOutput: "120", estimatedSeconds: 60, blocking: null, transactionSwap: {} },
+    ];
+    assert.equal(pickOffer(quotes, "cheapest").id, "b");
+  });
+
+  it("pickOffer picks min estimatedSeconds for 'fast'", () => {
+    const quotes = [
+      { id: "slow", estimatedOutput: "120", estimatedSeconds: 90, blocking: null, transactionSwap: {} },
+      { id: "fast", estimatedOutput: "100", estimatedSeconds: 10, blocking: null, transactionSwap: {} },
+    ];
+    assert.equal(pickOffer(quotes, "fast").id, "fast");
+  });
+
+  it("pickOffer prefers executable quotes over blocked ones (mirrors selectOffer)", () => {
+    const quotes = [
+      { id: "blocked", estimatedOutput: "999", blocking: { code: "not_enough_input_asset_balance" }, transactionSwap: null },
+      { id: "ok", estimatedOutput: "100", estimatedSeconds: 30, blocking: null, transactionSwap: {} },
+    ];
+    assert.equal(pickOffer(quotes, "cheapest").id, "ok");
+  });
+
+  it("pickOffer ignores non-finite estimatedOutput when picking cheapest", () => {
+    const quotes = [
+      { id: "broken", estimatedOutput: "NaN", blocking: null, transactionSwap: {} },
+      { id: "real", estimatedOutput: "100", blocking: null, transactionSwap: {} },
+    ];
+    assert.equal(pickOffer(quotes, "cheapest").id, "real");
+  });
+
+  it("pickOffer returns null on empty input", () => {
+    assert.equal(pickOffer([], "cheapest"), null);
+  });
+
+  it("pickOffer 'fast' falls back to cheapest when no quote has estimatedSeconds", () => {
+    const quotes = [
+      { id: "a", estimatedOutput: "100", blocking: null, transactionSwap: {} },
+      { id: "b", estimatedOutput: "120", blocking: null, transactionSwap: {} },
+    ];
+    assert.equal(pickOffer(quotes, "fast").id, "b", "should fall through to cheapest when no time data");
+  });
+
+  it("getSwapOffers throws no_route when API returns empty data", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+
+    await assert.rejects(
+      () => getSwapOffers({
+        fromToken: "ETH",
+        toToken: "USDC",
+        amount: "0.1",
+        fromChain: "ethereum",
+        toChain: "ethereum",
+        walletAddress: "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B",
+      }),
+      (err) => {
+        assert.equal(err.code, "no_route");
+        assert.match(err.message, /No swap route found/);
+        assert.ok(err.suggestion, "no_route error should carry a suggestion");
+        return true;
+      },
+    );
   });
 
   it("getSwapOffers returns every API offer mapped to the quote shape", async () => {

--- a/cli/tests/unit/cli/utils/trading/swap.test.mjs
+++ b/cli/tests/unit/cli/utils/trading/swap.test.mjs
@@ -323,6 +323,22 @@ describe("getSwapQuote — /swap/quotes/ migration", () => {
     assert.equal(picked.id, "big");
   });
 
+  it("isQuoteExecutable distinguishes 'no executable in pool' from 'all blocked for the same reason' (drives bridge's early-exit on insufficient balance)", () => {
+    // Three offers all blocked by `not_enough_input_asset_balance`. None are
+    // executable, but all share the same blocking code — the bridge command
+    // collapses this into a single insufficient_funds error rather than
+    // printing a table of unactionable routes.
+    const offers = [
+      { blocking: { code: "not_enough_input_asset_balance" }, transactionSwap: null, estimatedOutput: "1.0" },
+      { blocking: { code: "not_enough_input_asset_balance" }, transactionSwap: null, estimatedOutput: "0.99" },
+      { blocking: { code: "not_enough_input_asset_balance" }, transactionSwap: null, estimatedOutput: "0.98" },
+    ];
+    assert.equal(offers.filter(isQuoteExecutable).length, 0);
+    const blockingCodes = new Set(offers.map((o) => o.blocking?.code).filter(Boolean));
+    assert.equal(blockingCodes.size, 1);
+    assert.ok(blockingCodes.has("not_enough_input_asset_balance"));
+  });
+
   it("getSwapOffers throws no_route when API returns empty data", async () => {
     globalThis.fetch = async () =>
       new Response(JSON.stringify({ data: [] }), {

--- a/cli/tests/unit/cli/utils/trading/swap.test.mjs
+++ b/cli/tests/unit/cli/utils/trading/swap.test.mjs
@@ -5,7 +5,7 @@
 
 import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, it } from "node:test";
-import { getSwapQuote, getSwapOffers, selectOffer, pickOffer } from "#zerion/utils/trading/swap.js";
+import { getSwapQuote, getSwapOffers, selectOffer, pickOffer, isQuoteExecutable } from "#zerion/utils/trading/swap.js";
 
 const originalFetch = globalThis.fetch;
 const originalApiKey = process.env.ZERION_API_KEY;
@@ -285,6 +285,22 @@ describe("getSwapQuote — /swap/quotes/ migration", () => {
       { id: "b", estimatedOutput: "120", blocking: null, transactionSwap: {} },
     ];
     assert.equal(pickOffer(quotes, "fast").id, "b", "should fall through to cheapest when no time data");
+  });
+
+  it("isQuoteExecutable agrees with pickOffer's selection (no drift between display and execution)", () => {
+    const blockedQuote = { blocking: { code: "x" }, transactionSwap: {} };
+    const noTxQuote = { blocking: null, transactionSwap: null, transactionSwapSolana: null };
+    const evmQuote = { blocking: null, transactionSwap: { to: "0x" } };
+    const solanaQuote = { blocking: null, transactionSwapSolana: { raw: "abc" } };
+
+    assert.equal(isQuoteExecutable(blockedQuote), false, "blocked offer must not be marked executable");
+    assert.equal(isQuoteExecutable(noTxQuote), false, "no-error/no-tx offer must not be marked executable");
+    assert.equal(isQuoteExecutable(evmQuote), true);
+    assert.equal(isQuoteExecutable(solanaQuote), true);
+
+    // Cross-check with pickOffer: the same predicate drives selection.
+    const picked = pickOffer([noTxQuote, evmQuote], "cheapest");
+    assert.notEqual(picked, noTxQuote, "pickOffer must skip no-tx quote even when blocking is null");
   });
 
   it("getSwapOffers throws no_route when API returns empty data", async () => {

--- a/cli/tests/unit/cli/utils/trading/swap.test.mjs
+++ b/cli/tests/unit/cli/utils/trading/swap.test.mjs
@@ -90,8 +90,9 @@ describe("getSwapQuote — /swap/quotes/ migration", () => {
     assert.equal(req.searchParams.get("input[chain_id]"), "ethereum");
     assert.equal(req.searchParams.get("input[amount]"), "0.1");
     assert.equal(req.searchParams.get("output[chain_id]"), "ethereum");
-    // Same-chain swap — no `to` (defaults to `from`)
-    assert.equal(req.searchParams.has("to"), false);
+    // /swap/quotes/ requires `to` on every request — same-wallet bridges
+    // send the signer's address as the receiver, not omit the param.
+    assert.equal(req.searchParams.get("to"), sender);
     assert.equal(req.searchParams.has("output[to]"), false);
     // Old endpoint params must NOT be present
     assert.equal(req.searchParams.has("input[from]"), false);

--- a/cli/utils/api/client.js
+++ b/cli/utils/api/client.js
@@ -5,6 +5,10 @@
 // only analytics commands call. Trading commands hit this fallback and
 // always use the API key regardless of ZERION_X402 / ZERION_MPP env vars.
 
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
 import { API_BASE } from "../common/constants.js";
 import { basicAuthHeader, resolveApiKeyAuth } from "./auth.js";
 import { getX402Fetch } from "./x402.js";
@@ -12,6 +16,20 @@ import { getMppFetch } from "./mpp.js";
 
 const MAX_429_RETRIES = 5;
 const DEFAULT_429_BACKOFF_MS = 1000;
+
+// User-Agent identifies the CLI to Zerion's backend so swap/bridge calls are
+// attributable to agent traffic vs dashboard traffic. Resolved once at module
+// init from the package manifest; falls back to bare `zerion-cli` if the file
+// can't be read (e.g. tests with mocked fs).
+const USER_AGENT = (() => {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkg = JSON.parse(readFileSync(join(here, "..", "..", "..", "package.json"), "utf-8"));
+    return `zerion-cli/${pkg.version}`;
+  } catch {
+    return "zerion-cli";
+  }
+})();
 
 function parseRetryDelayMs(response) {
   // Prefer standard `Retry-After` (seconds or HTTP-date), then fall back to
@@ -45,7 +63,7 @@ export async function fetchAPI(pathname, params = {}, auth) {
     url.searchParams.set(key, String(value));
   }
 
-  const headers = { Accept: "application/json" };
+  const headers = { Accept: "application/json", "User-Agent": USER_AGENT };
   let fetchFn;
   switch (resolved.kind) {
     case "apiKey":

--- a/cli/utils/common/format.js
+++ b/cli/utils/common/format.js
@@ -174,6 +174,24 @@ export function formatSwapQuote(data) {
   return lines.join("\n");
 }
 
+export function formatBridgeOffers(data) {
+  const lines = [
+    `${BOLD}Bridge Quotes${RESET} — ${data.fromChain} → ${data.toChain}  ${DIM}(${data.amount} ${data.fromToken} → ${data.toToken})${RESET}\n`,
+  ];
+  lines.push(`  ${DIM}${pad("#", 3)} ${pad("Provider", 18)} ${padStart("Output", 14)} ${padStart("Time", 8)} ${padStart("Fee %", 8)}${RESET}`);
+  lines.push(`  ${DIM}${"─".repeat(54)}${RESET}`);
+  for (const [i, o] of data.offers.entries()) {
+    const time = o.estimatedSeconds != null ? `${o.estimatedSeconds}s` : "-";
+    const fee = o.fee?.protocolPercent != null ? `${Number(o.fee.protocolPercent).toFixed(2)}%` : "-";
+    const out = o.estimatedOutput ?? "-";
+    const provider = o.liquiditySource || "(unknown)";
+    lines.push(`  ${pad(i + 1, 3)} ${pad(provider, 18)} ${padStart(out, 14)} ${padStart(time, 8)} ${padStart(fee, 8)}`);
+  }
+  lines.push("");
+  lines.push(`  ${YELLOW}Pick one:${RESET} re-run with ${BOLD}--cheapest${RESET} (highest output) or ${BOLD}--fast${RESET} (lowest time).`);
+  return lines.join("\n");
+}
+
 export function formatHistory(data) {
   const lines = [`${BOLD}Transactions${RESET} — ${data.wallet.name} (${data.count})\n`];
   for (const tx of data.transactions) {

--- a/cli/utils/common/format.js
+++ b/cli/utils/common/format.js
@@ -19,6 +19,16 @@ function padStart(str, len) {
   return String(str).padStart(len);
 }
 
+// Truncate-then-pad. Use for table cells where overflow would push
+// neighboring columns out of alignment (e.g. liquidity-source provider names
+// like "stargate-v2-relayer" that exceed the column width).
+function padTrunc(str, len) {
+  const s = String(str);
+  if (s.length <= len) return s.padEnd(len);
+  // Reserve one char for the ellipsis so truncation is visible.
+  return s.slice(0, len - 1).padEnd(len, "…");
+}
+
 function usd(value) {
   if (value == null) return "-";
   return `$${Number(value).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
@@ -175,20 +185,38 @@ export function formatSwapQuote(data) {
 }
 
 export function formatBridgeOffers(data) {
+  // Column widths chosen to fit comfortably in 80-col terminals. Provider
+  // gets truncated (longest known: ~20 chars); numeric columns padStart so
+  // alignment holds even when values vary in length.
+  const W = { idx: 3, provider: 18, output: 14, time: 8, fee: 8, status: 10 };
+  const totalWidth = Object.values(W).reduce((a, b) => a + b, 0) + Object.keys(W).length - 1;
+
   const lines = [
     `${BOLD}Bridge Quotes${RESET} — ${data.fromChain} → ${data.toChain}  ${DIM}(${data.amount} ${data.fromToken} → ${data.toToken})${RESET}\n`,
   ];
-  lines.push(`  ${DIM}${pad("#", 3)} ${pad("Provider", 18)} ${padStart("Output", 14)} ${padStart("Time", 8)} ${padStart("Fee %", 8)}${RESET}`);
-  lines.push(`  ${DIM}${"─".repeat(54)}${RESET}`);
+  lines.push(`  ${DIM}${pad("#", W.idx)} ${pad("Provider", W.provider)} ${padStart("Output", W.output)} ${padStart("Time", W.time)} ${padStart("Fee %", W.fee)} ${pad("Status", W.status)}${RESET}`);
+  lines.push(`  ${DIM}${"─".repeat(totalWidth)}${RESET}`);
+  if (data.offers.length === 0) {
+    lines.push(`  ${DIM}(no offers)${RESET}`);
+  }
   for (const [i, o] of data.offers.entries()) {
     const time = o.estimatedSeconds != null ? `${o.estimatedSeconds}s` : "-";
     const fee = o.fee?.protocolPercent != null ? `${Number(o.fee.protocolPercent).toFixed(2)}%` : "-";
     const out = o.estimatedOutput ?? "-";
-    const provider = o.liquiditySource || "(unknown)";
-    lines.push(`  ${pad(i + 1, 3)} ${pad(provider, 18)} ${padStart(out, 14)} ${padStart(time, 8)} ${padStart(fee, 8)}`);
+    const provider = o.provider || o.liquiditySource || "(unknown)";
+    // Blocked offers stay in the table so users see the full route set, but
+    // we mark them clearly — pickOffer will skip these in favor of any
+    // executable offer, so the visual ordering ("biggest output wins") would
+    // otherwise mislead about what `--cheapest` actually selects.
+    const blocked = o.executable === false || o.blocking != null;
+    const status = blocked
+      ? `${RED}blocked${RESET}`
+      : `${GREEN}ready${RESET}`;
+    const row = `  ${pad(i + 1, W.idx)} ${padTrunc(provider, W.provider)} ${padStart(out, W.output)} ${padStart(time, W.time)} ${padStart(fee, W.fee)} ${status}`;
+    lines.push(blocked ? `${DIM}${row}${RESET}` : row);
   }
   lines.push("");
-  lines.push(`  ${YELLOW}Pick one:${RESET} re-run with ${BOLD}--cheapest${RESET} (highest output) or ${BOLD}--fast${RESET} (lowest time).`);
+  lines.push(`  ${YELLOW}Pick one:${RESET} re-run with ${BOLD}--cheapest${RESET} (highest output) or ${BOLD}--fast${RESET} (lowest time). Blocked offers are skipped automatically.`);
   return lines.join("\n");
 }
 

--- a/cli/utils/trading/guards.js
+++ b/cli/utils/trading/guards.js
@@ -178,7 +178,18 @@ export function parseSlippage(value) {
     });
     process.exit(1);
   }
-  const n = parseFloat(value);
+  // `parseFloat` would accept "2abc" as 2 — silently passing a malformed
+  // value through to the swap API. `Number()` rejects partial-numeric
+  // strings (returns NaN), which is what we want for a strict CLI flag.
+  // Trim whitespace first so " 2 " is still accepted, and reject the
+  // post-trim empty case (Number("") returns 0, which would slip through).
+  let n;
+  if (typeof value === "number") {
+    n = value;
+  } else {
+    const trimmed = String(value).trim();
+    n = trimmed === "" ? NaN : Number(trimmed);
+  }
   if (!Number.isFinite(n) || n < 0 || n > 100) {
     printError("invalid_slippage", `Invalid slippage: ${value}`, {
       suggestion: "Slippage must be a number between 0 and 100 (percent), e.g. --slippage 2",

--- a/cli/utils/trading/guards.js
+++ b/cli/utils/trading/guards.js
@@ -161,6 +161,34 @@ export function parseTimeout(value) {
 }
 
 /**
+ * Parse and validate a --slippage flag value (percent, 0-100). Returns
+ * undefined when the flag is absent so callers can fall back to defaults
+ * (config or DEFAULT_SLIPPAGE). Rejects negative, NaN, and >100 values that
+ * would otherwise sail through `parseFloat` and reach the swap API.
+ * @param {string|boolean|undefined} value - raw flag value
+ * @returns {number|undefined}
+ */
+export function parseSlippage(value) {
+  if (value === undefined || value === false) return undefined;
+  // `--slippage` with no following value parses as `true`. Treat it the same
+  // as a malformed value — reject rather than silently coerce to NaN.
+  if (typeof value !== "string" && typeof value !== "number") {
+    printError("invalid_slippage", `Invalid slippage: ${value}`, {
+      suggestion: "Slippage must be a number 0–100, e.g. --slippage 2",
+    });
+    process.exit(1);
+  }
+  const n = parseFloat(value);
+  if (!Number.isFinite(n) || n < 0 || n > 100) {
+    printError("invalid_slippage", `Invalid slippage: ${value}`, {
+      suggestion: "Slippage must be a number between 0 and 100 (percent), e.g. --slippage 2",
+    });
+    process.exit(1);
+  }
+  return n;
+}
+
+/**
  * Shared catch-block handler for trading commands.
  * Detects revoked agent tokens and falls back to a generic error.
  * @param {Error} err

--- a/cli/utils/trading/swap.js
+++ b/cli/utils/trading/swap.js
@@ -72,10 +72,8 @@ async function hasSufficientAllowance({ zerionChainId, approveTx, owner }) {
   }
 }
 
-/**
- * Get a swap/bridge quote from Zerion API.
- */
-export async function getSwapQuote({
+// Build the /swap/quotes/ params and resolve the from/to tokens once.
+async function buildQuoteRequest({
   fromToken,
   toToken,
   amount,
@@ -108,36 +106,16 @@ export async function getSwapQuote({
     params.to = outputReceiver;
   }
 
-  const response = await api.getSwapQuotes(params);
-  const offers = response.data || [];
+  return { params, fromResolved, toResolved };
+}
 
-  if (offers.length === 0) {
-    const err = new Error(
-      `No swap route found for ${amount} ${fromResolved.symbol} → ${toResolved.symbol} on ${fromChain}. ` +
-      `Minimum swap is ~$1. ` +
-      `Check your balance and chain with: zerion portfolio`
-    );
-    err.code = "no_route";
-    err.suggestion = `Try a smaller amount or different pair: zerion swap ${fromChain} 0.001 ETH USDC`;
-    throw err;
-  }
-
-  // Pick the first offer that has executable transaction data. The API may
-  // return offers with `error` set (e.g. not_enough_input_asset_balance) —
-  // those carry no transaction_swap and aren't actionable.
-  const executable = offers.find((o) => {
-    const a = o.attributes || {};
-    if (a.error) return false;
-    return Boolean(a.transaction_swap?.evm || a.transaction_swap?.solana);
-  });
-  const best = executable || offers[0];
-  const attrs = best.attributes || {};
-
-  // Surface the API's blocking error before downstream code tries to sign.
+// Shape an API offer into our internal quote object. Heavy enough to share
+// between single-quote selection and the offers-list view.
+function offerToQuote(offer, { fromResolved, toResolved, fromChain, toChain, amount, walletAddress, outputReceiver }) {
+  const attrs = offer.attributes || {};
   const blocking = attrs.error;
-
   return {
-    id: best.id,
+    id: offer.id,
     from: fromResolved,
     to: toResolved,
     inputAmount: amount,
@@ -150,8 +128,6 @@ export async function getSwapQuote({
       networkAmount: attrs.network_fee?.amount?.quantity,
     },
     liquiditySource: attrs.liquidity_source?.name,
-    // Translate the new error shape into the boolean preconditions our
-    // commands check before signing.
     preconditions: {
       enough_balance: blocking?.code !== "not_enough_input_asset_balance",
     },
@@ -164,6 +140,105 @@ export async function getSwapQuote({
     outputReceiver: outputReceiver || walletAddress,
     slippageType: attrs.slippage?.final ? "absolute" : undefined,
   };
+}
+
+function isExecutable(offer) {
+  const a = offer.attributes || {};
+  if (a.error) return false;
+  return Boolean(a.transaction_swap?.evm || a.transaction_swap?.solana);
+}
+
+// Offer selection strategies.
+//   "cheapest": highest net `output_amount` (matches API's default sort).
+//   "fast":     lowest `estimated_time_seconds`. Offers with no time data
+//               fall back to "cheapest" ordering.
+// Both strategies prefer executable offers; non-executable offers (e.g.
+// `error: not_enough_input_asset_balance`) only win when nothing else is
+// available so the caller can surface the blocking error.
+export function selectOffer(offers, strategy = "cheapest") {
+  if (!offers.length) return null;
+
+  const executable = offers.filter(isExecutable);
+  const pool = executable.length ? executable : offers;
+
+  if (strategy === "fast") {
+    const timed = pool.filter((o) => Number.isFinite(o.attributes?.estimated_time_seconds));
+    if (timed.length) {
+      return timed.reduce((best, o) =>
+        o.attributes.estimated_time_seconds < best.attributes.estimated_time_seconds ? o : best
+      );
+    }
+    // No time data on any offer — fall through to cheapest.
+  }
+
+  // "cheapest" — pick max output_amount.quantity (numeric compare).
+  return pool.reduce((best, o) => {
+    const bestOut = parseFloat(best.attributes?.output_amount?.quantity || "0");
+    const oOut = parseFloat(o.attributes?.output_amount?.quantity || "0");
+    return oOut > bestOut ? o : best;
+  });
+}
+
+function noRouteError(amount, fromResolved, toResolved, fromChain) {
+  const err = new Error(
+    `No swap route found for ${amount} ${fromResolved.symbol} → ${toResolved.symbol} on ${fromChain}. ` +
+    `Minimum swap is ~$1. ` +
+    `Check your balance and chain with: zerion portfolio`
+  );
+  err.code = "no_route";
+  err.suggestion = `Try a smaller amount or different pair: zerion swap ${fromChain} 0.001 ETH USDC`;
+  return err;
+}
+
+/**
+ * Get a single swap/bridge quote, picked by strategy ("cheapest" | "fast").
+ * "cheapest" is the legacy default — matches the API's first-offer ordering
+ * and never changes behavior for existing callers.
+ */
+export async function getSwapQuote(input) {
+  const strategy = input.strategy || "cheapest";
+  const { params, fromResolved, toResolved } = await buildQuoteRequest(input);
+  const response = await api.getSwapQuotes(params);
+  const offers = response.data || [];
+
+  if (offers.length === 0) {
+    throw noRouteError(input.amount, fromResolved, toResolved, input.fromChain);
+  }
+
+  const picked = selectOffer(offers, strategy);
+  return offerToQuote(picked, {
+    fromResolved,
+    toResolved,
+    fromChain: input.fromChain,
+    toChain: input.toChain,
+    amount: input.amount,
+    walletAddress: input.walletAddress,
+    outputReceiver: input.outputReceiver,
+  });
+}
+
+/**
+ * List ALL swap/bridge offers without picking one. Used by `zerion bridge`
+ * (no flag) so the agent can compare providers before committing.
+ */
+export async function getSwapOffers(input) {
+  const { params, fromResolved, toResolved } = await buildQuoteRequest(input);
+  const response = await api.getSwapQuotes(params);
+  const offers = response.data || [];
+
+  if (offers.length === 0) {
+    throw noRouteError(input.amount, fromResolved, toResolved, input.fromChain);
+  }
+
+  return offers.map((o) => offerToQuote(o, {
+    fromResolved,
+    toResolved,
+    fromChain: input.fromChain,
+    toChain: input.toChain,
+    amount: input.amount,
+    walletAddress: input.walletAddress,
+    outputReceiver: input.outputReceiver,
+  }));
 }
 
 /**

--- a/cli/utils/trading/swap.js
+++ b/cli/utils/trading/swap.js
@@ -148,7 +148,7 @@ function isExecutable(offer) {
   return Boolean(a.transaction_swap?.evm || a.transaction_swap?.solana);
 }
 
-// Offer selection strategies.
+// Offer selection strategies — operate on RAW API offers (`offer.attributes…`).
 //   "cheapest": highest net `output_amount` (matches API's default sort).
 //   "fast":     lowest `estimated_time_seconds`. Offers with no time data
 //               fall back to "cheapest" ordering.
@@ -171,12 +171,38 @@ export function selectOffer(offers, strategy = "cheapest") {
     // No time data on any offer — fall through to cheapest.
   }
 
-  // "cheapest" — pick max output_amount.quantity (numeric compare).
-  return pool.reduce((best, o) => {
-    const bestOut = parseFloat(best.attributes?.output_amount?.quantity || "0");
-    const oOut = parseFloat(o.attributes?.output_amount?.quantity || "0");
-    return oOut > bestOut ? o : best;
-  });
+  // "cheapest" — pick max output_amount.quantity. parseFloat returns NaN for
+  // non-numeric strings; treat any non-finite (NaN, Infinity, missing) as
+  // ineligible so a malformed first offer can't anchor the reducer and beat
+  // every later candidate.
+  const numericOut = (o) => {
+    const n = parseFloat(o.attributes?.output_amount?.quantity);
+    return Number.isFinite(n) ? n : -Infinity;
+  };
+  return pool.reduce((best, o) => (numericOut(o) > numericOut(best) ? o : best));
+}
+
+// Mapped-quote selection — same strategy semantics as selectOffer, but works
+// on the post-`offerToQuote` shape so callers (`bridge`) don't have to refetch
+// the API to get a single quote after listing offers.
+export function pickOffer(quotes, strategy = "cheapest") {
+  if (!quotes.length) return null;
+
+  const executable = quotes.filter((q) => q.blocking == null && (q.transactionSwap || q.transactionSwapSolana));
+  const pool = executable.length ? executable : quotes;
+
+  if (strategy === "fast") {
+    const timed = pool.filter((q) => Number.isFinite(q.estimatedSeconds));
+    if (timed.length) {
+      return timed.reduce((best, q) => (q.estimatedSeconds < best.estimatedSeconds ? q : best));
+    }
+  }
+
+  const out = (q) => {
+    const n = parseFloat(q.estimatedOutput);
+    return Number.isFinite(n) ? n : -Infinity;
+  };
+  return pool.reduce((best, q) => (out(q) > out(best) ? q : best));
 }
 
 function noRouteError(amount, fromResolved, toResolved, fromChain) {

--- a/cli/utils/trading/swap.js
+++ b/cli/utils/trading/swap.js
@@ -98,13 +98,13 @@ async function buildQuoteRequest({
     "slippage_percent": slippage ?? getConfigValue("slippage") ?? DEFAULT_SLIPPAGE,
   };
 
-  // Cross-chain destinations are passed as the top-level `to` param, NOT
-  // `output[to]`. /swap/quotes/ defaults `to` to `from` when omitted, which
-  // breaks Solana ↔ EVM bridges (chain types don't match). Always send `to`
-  // when we have one different from `from`.
-  if (outputReceiver && outputReceiver !== walletAddress) {
-    params.to = outputReceiver;
-  }
+  // The /swap/quotes/ endpoint requires `to` on every request — it used to
+  // default to `from` when omitted, but the API now rejects with
+  // "'to' is required". Always send it. For same-wallet bridges this is
+  // the source signer's address on the destination chain (resolved by
+  // resolveDestination upstream); for Solana ↔ EVM it's the user-provided
+  // receiver. Receivers must be passed at the top level, NOT `output[to]`.
+  params.to = outputReceiver || walletAddress;
 
   return { params, fromResolved, toResolved };
 }

--- a/cli/utils/trading/swap.js
+++ b/cli/utils/trading/swap.js
@@ -195,24 +195,40 @@ export function isQuoteExecutable(quote) {
 // Mapped-quote selection — same strategy semantics as selectOffer, but works
 // on the post-`offerToQuote` shape so callers (`bridge`) don't have to refetch
 // the API to get a single quote after listing offers.
+//
+// Selection order:
+//   1. If any executable quote exists → pick from those by strategy.
+//   2. Else if any blocked quote has a real API error → return the
+//      highest-output one so executeSwap can surface that error message.
+//   3. Else (only no-tx / no-error quotes) → return null. The caller
+//      treats this as no_route, which is correct: nothing in the response
+//      is signable AND nothing in the response carries actionable info.
 export function pickOffer(quotes, strategy = "cheapest") {
   if (!quotes.length) return null;
-
-  const executable = quotes.filter(isQuoteExecutable);
-  const pool = executable.length ? executable : quotes;
-
-  if (strategy === "fast") {
-    const timed = pool.filter((q) => Number.isFinite(q.estimatedSeconds));
-    if (timed.length) {
-      return timed.reduce((best, q) => (q.estimatedSeconds < best.estimatedSeconds ? q : best));
-    }
-  }
 
   const out = (q) => {
     const n = parseFloat(q.estimatedOutput);
     return Number.isFinite(n) ? n : -Infinity;
   };
-  return pool.reduce((best, q) => (out(q) > out(best) ? q : best));
+
+  const executable = quotes.filter(isQuoteExecutable);
+  if (executable.length) {
+    if (strategy === "fast") {
+      const timed = executable.filter((q) => Number.isFinite(q.estimatedSeconds));
+      if (timed.length) {
+        return timed.reduce((best, q) => (q.estimatedSeconds < best.estimatedSeconds ? q : best));
+      }
+    }
+    return executable.reduce((best, q) => (out(q) > out(best) ? q : best));
+  }
+
+  // No executable quotes — surface the best blocked-with-error candidate so
+  // executeSwap throws a meaningful message. If even that's missing (no
+  // executable AND no blocking error), there is nothing signable here and
+  // the caller should treat it as a routing failure.
+  const informative = quotes.filter((q) => q.blocking != null);
+  if (!informative.length) return null;
+  return informative.reduce((best, q) => (out(q) > out(best) ? q : best));
 }
 
 function noRouteError(amount, fromResolved, toResolved, fromChain) {

--- a/cli/utils/trading/swap.js
+++ b/cli/utils/trading/swap.js
@@ -182,13 +182,23 @@ export function selectOffer(offers, strategy = "cheapest") {
   return pool.reduce((best, o) => (numericOut(o) > numericOut(best) ? o : best));
 }
 
+// True iff the quote can be signed and broadcast: no API-side blocking
+// error AND a transaction payload is present. `bridge` reuses this so the
+// "executable" flag in list-mode output matches what `pickOffer` would
+// actually select — otherwise a no-error/no-tx offer would render as
+// `ready` and silently get skipped at execution time.
+export function isQuoteExecutable(quote) {
+  if (!quote || quote.blocking != null) return false;
+  return Boolean(quote.transactionSwap || quote.transactionSwapSolana);
+}
+
 // Mapped-quote selection — same strategy semantics as selectOffer, but works
 // on the post-`offerToQuote` shape so callers (`bridge`) don't have to refetch
 // the API to get a single quote after listing offers.
 export function pickOffer(quotes, strategy = "cheapest") {
   if (!quotes.length) return null;
 
-  const executable = quotes.filter((q) => q.blocking == null && (q.transactionSwap || q.transactionSwapSolana));
+  const executable = quotes.filter(isQuoteExecutable);
   const pool = executable.length ? executable : quotes;
 
   if (strategy === "fast") {

--- a/skills/zerion-trading/SKILL.md
+++ b/skills/zerion-trading/SKILL.md
@@ -83,9 +83,8 @@ Move (and optionally swap) tokens **between chains**. Bridge with the same token
 
 Rules:
 - `--fast` and `--cheapest` together is rejected.
-- Strategy flags MUST appear last on the command line (or with `=` form, e.g. `--fast=true`). `parseFlags` will otherwise consume the next positional token as the flag value — the CLI errors with `invalid_flag_value` rather than silently picking up a chain name as the flag value.
-- `--no-fast` / `--no-cheapest` are accepted (treated as unset).
-- `--slippage` is now validated: must be a number between 0 and 100. `--slippage abc`, `--slippage -5`, `--slippage 200` all reject with `invalid_slippage`.
+- Supported flag forms: bare `--fast` (must be last on the command line so `parseFlags` doesn't consume the next positional as the value), `--fast=true` / `--fast=false`, and `--no-fast` (equivalent to `--fast=false`). Same shape applies to `--cheapest`. Anything else (e.g. `--fast=cheapest`, `--fast arbitrum`) errors with `invalid_flag_value`.
+- `--slippage` is validated: must be a number between 0 and 100. `--slippage=abc`, `--slippage=2abc`, `--slippage=-5`, `--slippage=200` all reject with `invalid_slippage`. Strict numeric parse — no partial-string matches.
 
 ```bash
 # zerion bridge <from-chain> <from-token> <amount> <to-chain> <to-token> [--fast | --cheapest]

--- a/skills/zerion-trading/SKILL.md
+++ b/skills/zerion-trading/SKILL.md
@@ -72,35 +72,56 @@ zerion swap tokens solana                # filter to Solana
 
 Move (and optionally swap) tokens **between chains**. Bridge with the same token on both sides for a pure transfer; pass a different `to-token` for bridge + swap.
 
-```bash
-# zerion bridge <from-chain> <from-token> <amount> <to-chain> <to-token>
+**Provider selection:**
 
-# Same-token bridge between EVM chains
+| Flag | Behavior |
+|---|---|
+| _(none)_, multi-offer | List every quote (provider, output, time, fee) and exit. **No transaction is signed.** |
+| _(none)_, single-offer | Auto-execute the only available route (no choice to make). |
+| `--cheapest` | Execute the highest-output offer (matches the legacy auto-execute behavior). |
+| `--fast` | Execute the lowest-time offer (`estimated_time_seconds`). Falls back to `--cheapest` if no offer carries time data. |
+
+Rules:
+- `--fast` and `--cheapest` together is rejected.
+- Strategy flags MUST appear last on the command line (or with `=` form, e.g. `--fast=true`). `parseFlags` will otherwise consume the next positional token as the flag value — the CLI errors with `invalid_flag_value` rather than silently picking up a chain name as the flag value.
+- `--no-fast` / `--no-cheapest` are accepted (treated as unset).
+- `--slippage` is now validated: must be a number between 0 and 100. `--slippage abc`, `--slippage -5`, `--slippage 200` all reject with `invalid_slippage`.
+
+```bash
+# zerion bridge <from-chain> <from-token> <amount> <to-chain> <to-token> [--fast | --cheapest]
+
+# List all bridge providers (no execution) — agent can compare and choose
 zerion bridge base USDC 5 arbitrum USDC
-zerion bridge ethereum USDC 100 polygon USDC
+
+# Same-token bridge — execute the cheapest (highest output) route
+zerion bridge base USDC 5 arbitrum USDC --cheapest
+zerion bridge ethereum USDC 100 polygon USDC --cheapest
+
+# Execute the fastest route (lowest estimated_time_seconds)
+zerion bridge base USDC 5 arbitrum USDC --fast
 
 # Bridge + swap on destination
-zerion bridge base USDC 5 arbitrum ETH
+zerion bridge base USDC 5 arbitrum ETH --cheapest
 
 # Native token bridge
-zerion bridge base ETH 0.001 optimism ETH
+zerion bridge base ETH 0.001 optimism ETH --cheapest
 
 # Bridge EVM → Solana (mnemonic wallet has both accounts → no extra flag needed)
-zerion bridge ethereum USDC 50 solana USDC
+zerion bridge ethereum USDC 50 solana USDC --cheapest
 
 # Bridge Solana → EVM
-zerion bridge solana USDC 50 ethereum USDC
+zerion bridge solana USDC 50 ethereum USDC --cheapest
 
 # Cross-format bridge to a different local wallet
-zerion bridge ethereum USDC 50 solana USDC --to-wallet <sol-wallet>
-zerion bridge solana USDC 50 ethereum USDC --to-wallet <evm-wallet>
+zerion bridge ethereum USDC 50 solana USDC --to-wallet <sol-wallet> --cheapest
+zerion bridge solana USDC 50 ethereum USDC --to-wallet <evm-wallet> --cheapest
 
 # Bridge to a raw destination address (must match the target chain's format)
-zerion bridge ethereum USDC 50 solana USDC --to-address <solana-pubkey>
-zerion bridge solana USDC 50 ethereum USDC --to-address 0x...
+zerion bridge ethereum USDC 50 solana USDC --to-address <solana-pubkey> --cheapest
+zerion bridge solana USDC 50 ethereum USDC --to-address 0x... --cheapest
 
-# Slippage / timeout flags work the same as swap
-zerion bridge base USDC 5 arbitrum ETH --slippage 3 --timeout 300
+# Slippage / timeout flags work the same as swap (strategy flag still last)
+zerion bridge base USDC 5 arbitrum ETH --slippage 3 --timeout 300 --cheapest
 ```
 
 ### Cross-chain destination rules


### PR DESCRIPTION
## Summary

Addresses three Superteam Earn hackathon feedback items + a live API regression caught during manual testing. Two rounds of adversarial review (Codex + Claude multi-specialist) shipped 17 fixes total.

**Linked:** WLT-9140

## What's in this PR

### 1. Bridge provider selection (`--fast` / `--cheapest`)
`zerion bridge` no longer silently picks the cheapest route. Default behavior now lists every quote (provider, output, time, fee, status) so the agent can compare. Append a strategy flag to execute:

- `--cheapest` → highest net `output_amount` (matches the legacy auto-execute behavior)
- `--fast` → lowest `estimated_time_seconds`
- `--fast=true` / `--no-fast` / `--fast=false` all accepted (bool-flag conventions)
- `--fast` and `--cheapest` together rejected
- Single-offer responses auto-execute (no choice to make)
- All offers blocked by `not_enough_input_asset_balance` → exits early with `insufficient_funds` instead of printing an unactionable table

### 2. Fee attribution via `User-Agent`
`fetchAPI` now sends `User-Agent: zerion-cli/<version>` on every request to `api.zerion.io`. Backend can attribute swap/bridge/send traffic to the agent CLI vs dashboard. Header propagates through both x402 and MPP fetch wrappers.

### 3. Expanded chains list
`router.js` `--help` chains array updated from 14 to 45 trading-supported chains pulled from the live `/chains/` API. Adds Monad, Abstract, Sonic, Mantle, Unichain, Berachain, Hyperevm, Sei, Soneium, World, and 30+ others. Note in usage points to `zerion chains` for the live list.

### 4. Slippage validation
`--slippage` is now strictly validated: 0–100, no partial-string parses (`parseFloat("2abc")` would have passed `2` to the API). Rejects `NaN`, negative, `>100`, empty, and partial strings with `invalid_slippage`. Applied to both `swap` and `bridge`.

### 5. Live API fix: always send `to`
Caught during manual testing — the `/swap/quotes/` endpoint started rejecting requests without an explicit `to` param (it used to default to `from`). `bridge base USDC 5 arbitrum USDC` returned 400 on every same-wallet bridge. Now always sends the resolved receiver.

## Behavior change (heads up)

`zerion bridge ...` with **no** strategy flag previously auto-executed the cheapest route. It now prints the offer table and exits without signing. Existing scripts/skills that called bare `zerion bridge` will need `--cheapest` appended to keep the old behavior.

Docs updated:
- `README.md` — bridge example table updated with `--cheapest` / `--fast`
- `skills/zerion-trading/SKILL.md` — provider selection table + flag rules + slippage validation note

## Tests

- 159 tests pass (was 135 baseline + 24 new)
- New: `cli/tests/unit/cli/commands/trading/bridge.test.mjs` — 12 subprocess-based tests covering flag validation, slippage rejection, --no-fast acceptance, mid-position --fast, missing args, same-chain rejection
- New: `cli/tests/unit/cli/utils/common/format.test.mjs` — 7 tests for `formatBridgeOffers` (header, rows, missing fields, truncation, blocked-status, hint, empty-offers)
- Expanded: `swap.test.mjs` — `selectOffer` strategy semantics, `pickOffer` mapped-quote selector, `getSwapOffers` empty-data, `isQuoteExecutable` parity check, NaN guard, all-blocked fallback
- Expanded: `client.test.mjs` — strict UA regex (rejects fallback), wrapper passthrough

## Review history

Two rounds of multi-model review:

1. **Round 1 (Codex challenge):** 6 issues — single-offer race, list-by-default doc drift, `--fast=false` truthy, `selectOffer` NaN, formatter field mismatch, UA test regex. All fixed in `aac372e`.
2. **Round 2 (Claude /review with testing + maintainability + security + adversarial specialists):** 7 issues — slippage validation gap, `--no-fast` misleading error, blocked-offer visibility, provider name overflow, missing bridge tests, `pickOffer` empty-truthy, missing format tests. All fixed in `aac372e` + `7401192`.
3. **Round 3 (Codex re-verification):** 4 lingering issues — `parseFloat` partial match, list-mode executable mismatch, SKILL.md `--fast=true` claim, `pickOffer` non-executable fallback. All fixed in `7401192` + `0d5cbae`.
4. **Round 4 (Codex final):** clean.

Fifth pass during manual testing caught the live API `to` regression (`4f1ab1f`) and the all-blocked-balance UX gap (`56bc2fd`).

## Test plan

- [ ] Pull this branch, run `npm test` — expect 159 pass
- [ ] `node cli/zerion.js bridge` with no args → `missing_args` error
- [ ] `node cli/zerion.js bridge base USDC 5 arbitrum USDC` with funded wallet → offer table, exits without signing
- [ ] Same command with empty wallet → `insufficient_funds` early-exit (not table)
- [ ] `... --cheapest` → executes highest-output offer
- [ ] `... --fast` → executes lowest-time offer
- [ ] `... --fast --cheapest` → `conflicting_flags`
- [ ] `... --slippage=2abc --cheapest` → `invalid_slippage`
- [ ] `... --no-fast` → not rejected by validator
- [ ] Verify `User-Agent: zerion-cli/<version>` reaches the backend (point `ZERION_API_BASE` at a local listener)
- [ ] `node cli/zerion.js --help | jq '.chains | length'` → 45
- [ ] Confirm `monad` appears in the chains array

🤖 Generated with [Claude Code](https://claude.com/claude-code)