### PR TITLE
docs(readme): default to init + add partner skills directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,7 @@ CLI for [Zerion Wallet](https://zerion.io). Analyze wallets, sign, swap, and bri
 
 ## Installation
 
-```bash
-npm install -g zerion-cli
-```
-
-Or set up everything in one command (install CLI globally, configure your API key, and add skills across all detected coding agents):
+Set up everything in one command (install CLI globally, configure your API key, and add skills across all detected coding agents):
 
 ```bash
 npx -y zerion-cli init -y --browser
@@ -20,6 +16,12 @@ npx -y zerion-cli init -y --browser
 - `-y` runs setup non-interactively
 - `--browser` opens [dashboard.zerion.io](https://dashboard.zerion.io) so you can grab an API key and paste it back
 - skills install globally to every detected AI coding agent by default
+
+Or just install the CLI without setup:
+
+```bash
+npm install -g zerion-cli
+```
 
 Requires Node.js 20 or later.
 


### PR DESCRIPTION
## Summary
- Promote \`npx -y zerion-cli init -y --browser\` as primary install (full setup); demote \`npm install -g\` to secondary
- Split skills section into **Core** (6 Zerion skills) and **Partner** (9 ecosystem skills) tables
- Partner table covers: Monad, MoonPay (onramp / Iron / predict), SendAI, Somnia (blockchain / reactivity), Trails (crosschainswap / deposit)
- Link each partner skill to its provider; point contributors at \`zerion-partner-skill-creator\`

## Test plan
- [ ] Render README on GitHub and confirm both tables, all 15 SKILL.md links resolve
- [ ] Verify install snippets copy cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)