### PR TITLE
fix(zerion-uniswap-x402): use canonical 5-arg zerion bridge signature

### DIFF
--- a/skills/zerion-uniswap-x402/SKILL.md
+++ b/skills/zerion-uniswap-x402/SKILL.md
@@ -19,7 +19,7 @@ license: MIT
 
 **Zerion CLI (shell):**
 - `zerion positions <address>` — check token balances by chain
-- `zerion bridge <token> <chain> <amount> --to-address <address> --cheapest` — optionally pre-position capital to the signing wallet
+- `zerion bridge <from-chain> <from-token> <amount> <to-chain> <to-token> --to-address <address> --cheapest` — optionally pre-position capital to the signing wallet
 - `zerion portfolio <address>` — verify balance before paying
 
 ## Requirements
@@ -71,7 +71,7 @@ Two paths — choose one:
 
 **Path A — Pre-bridge with Zerion CLI:**
 ```bash
-zerion bridge USDC base 50 --to-address $WALLET --cheapest
+zerion bridge ethereum USDC 50 base USDC --to-address $WALLET --cheapest
 ```
 Funds land in the signing wallet on the target chain. Use `--cheapest` to minimise bridge fees.
 


### PR DESCRIPTION
## Summary
- Restore canonical `zerion bridge <from-chain> <from-token> <amount> <to-chain> <to-token>` signature in `zerion-uniswap-x402` (regressed to 3-arg form, which CLI rejects with `missing_args`)
- Aligns with the form already used in `zerion-uniswap-lp`
- Path A agentic runs previously failed at step 2; Path B was unaffected
- Add missing trailing newline at EOF

## Diff
- Key Commands line: `zerion bridge <from-chain> <from-token> <amount> <to-chain> <to-token> --to-address <address> --cheapest`
- Step 2 Path A example: `zerion bridge ethereum USDC 50 base USDC --to-address \$WALLET --cheapest`

## Test plan
- [ ] Run `zerion bridge ethereum USDC 50 base USDC --to-address \$WALLET --cheapest` against a funded wallet — completes without `missing_args`
- [ ] Confirm trailing newline present (`tail -c 1 skills/zerion-uniswap-x402/SKILL.md | xxd` shows `0a`)
- [ ] Visual diff with `zerion-uniswap-lp/SKILL.md` — signatures match

🤖 Generated with [Claude Code](https://claude.com/claude-code)