### PR TITLE
feat: support global --agent-token CLI flag for programmatic auth

### DIFF
--- a/cli/zerion.js
+++ b/cli/zerion.js
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 
+
+
 /**
  * Zerion CLI — unified entry point for wallet analysis and trading.
  * Routes argv to command handlers via the router.
  */
-
 import { register, registerSingle, dispatch } from "./router.js";
 import { printError, setPrettyMode } from "./utils/common/output.js";
 import { migrateFromZerionCli } from "./utils/common/migrate.js";
+import { parseFlags } from "./utils/common/flags.js";
 
 // Migrate config from ~/.zerion-cli → ~/.zerion on first run after upgrade
 migrateFromZerionCli();
@@ -17,8 +19,13 @@ if (process.argv.includes("--pretty") || (process.stdout.isTTY && !process.argv.
   setPrettyMode(true);
 }
 
-// --- Wallet management ---
+// Global interceptor for --agent-token flag
+const { flags } = parseFlags(process.argv.slice(2));
+if (flags["agent-token"]) {
+  process.env.ZERION_AGENT_TOKEN = flags["agent-token"];
+}
 
+// --- Wallet management ---
 import walletCreate from "./commands/wallet/create.js";
 import walletImport from "./commands/wallet/import.js";
 import walletList from "./commands/wallet/list.js";


### PR DESCRIPTION
### What does this PR do?

Currently, the `zerion-cli` does not parse or respect the `--agent-token` flag passed via command line arguments. Developers automating the CLI in CI/CD or wrapping it in child processes are forced to inject `ZERION_AGENT_TOKEN` into `process.env`. 
This PR adds a global parser at the entry point to automatically map the `--agent-token` argument to `process.env.ZERION_AGENT_TOKEN`, allowing commands like:
`zerion swap base 1 USDC ETH --agent-token <token>` to work out-of-the-box as developers expect.

### Why is it important?
When building autonomous agents that juggle multiple wallets (e.g., an EVM wallet and a Solana wallet), developers need to switch agent tokens dynamically per command. Injecting environment variables into Node.js child processes is error-prone, whereas passing a CLI flag is standard and declarative.