### PR TITLE
docs: document wallet export-key command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ One skill, [`zerion`](./skills/zerion/SKILL.md), under [`./skills/zerion/`](./sk
 | [`analyze.md`](./skills/zerion/capabilities/analyze.md) | Portfolio, positions, history, PnL, token search, watchlist (read-only; supports x402 / MPP) |
 | [`trading.md`](./skills/zerion/capabilities/trading.md) | Swap, bridge, send tokens (on-chain actions; needs API key + agent token) |
 | [`sign.md`](./skills/zerion/capabilities/sign.md) | Off-chain signing — sign-message (EIP-191 / raw), sign-typed-data (EIP-712) |
-| [`wallet.md`](./skills/zerion/capabilities/wallet.md) | Wallet management — create, import, list, fund, backup, delete, sync |
+| [`wallet.md`](./skills/zerion/capabilities/wallet.md) | Wallet management — create, import, list, fund, backup, export-key, delete, sync |
 | [`agent-management.md`](./skills/zerion/capabilities/agent-management.md) | Agent tokens + policies (the autonomous-trading primitives) |
 | [`swap-0x.md`](./skills/zerion/capabilities/swap-0x.md) | Token swaps via 0x API v2 — AllowanceHolder, Permit2, and Gasless flows across 20+ EVM chains |
 
@@ -138,7 +138,7 @@ The agent reaches for the `zerion` skill, which routes by task to the right nest
 
 Zerion CLI splits into two surfaces, by design.
 
-- **Wallet management and agent token setup are manual.** `wallet create`, `import`, `backup`, and `delete` all prompt for a passphrase. `wallet sync` emits a QR code you scan with the Zerion app. `agent create-token` mints a scoped trading credential bound to a specific wallet, and `agent create-policy` attaches the rules it has to obey — allowed chains, expiry, transfer/approval gates, contract allowlists. The sibling admin commands (`agent list-tokens`, `use-token`, `revoke-token`, `list-policies`, `show-policy`, `delete-policy`) are also gestures you make yourself. No key material moves and no spending credential widens without you in the loop. For CI and headless servers, `agent create-token` accepts `--passphrase-file <path>` (file must be mode `0600`) so token issuance can be scripted without an interactive TTY — see [`capabilities/agent-management.md`](./skills/zerion/capabilities/agent-management.md).
+- **Wallet management and agent token setup are manual.** `wallet create`, `import`, `backup`, `export-key`, and `delete` all prompt for a passphrase. `wallet sync` emits a QR code you scan with the Zerion app. `agent create-token` mints a scoped trading credential bound to a specific wallet, and `agent create-policy` attaches the rules it has to obey — allowed chains, expiry, transfer/approval gates, contract allowlists. The sibling admin commands (`agent list-tokens`, `use-token`, `revoke-token`, `list-policies`, `show-policy`, `delete-policy`) are also gestures you make yourself. No key material moves and no spending credential widens without you in the loop. For CI and headless servers, `agent create-token` accepts `--passphrase-file <path>` (file must be mode `0600`) so token issuance can be scripted without an interactive TTY — see [`capabilities/agent-management.md`](./skills/zerion/capabilities/agent-management.md).
 - **Analysis, signing, trading, and discovery are for agents.** `analyze`, `portfolio`, `positions`, `history`, `pnl`, `sign-message`, `sign-typed-data`, `swap`, `bridge`, `send`, `swap tokens`, `search`, `chains`, `wallet list`, `wallet fund`, and `watch list` emit JSON to stdout, structured errors to stderr, and skip confirmation dialogs. Once an agent token is configured, signing and trading fire immediately — the token authorizes operations on behalf of the wallet without a passphrase prompt.
 
 Setup gestures (`init`, `setup skills`, `config set/unset/list`, `watch` add/remove) are one-time configuration steps you run yourself before automation takes over.
@@ -251,6 +251,7 @@ Encrypted local wallets. EVM + Solana supported. Passphrase required for all des
 | `zerion wallet list` | List all wallets | `zerion wallet list` |
 | `zerion wallet fund` | Show deposit addresses for funding | `zerion wallet fund --wallet trading-bot` |
 | `zerion wallet backup --wallet <name>` | Export recovery phrase | `zerion wallet backup --wallet trading-bot` |
+| `zerion wallet export-key --wallet <name> [--chain evm\|solana\|all] [--index N]` | Export raw private key(s) derived from mnemonic — EVM (0x hex) and/or Solana (base58 Phantom format + 32-byte ed25519 seed). Output is stderr-only. | `zerion wallet export-key --wallet trading-bot --chain evm` |
 | `zerion wallet delete <name>` | Permanently delete a wallet (requires passphrase) | `zerion wallet delete trading-bot` |
 | `zerion wallet sync --wallet <name>` | Sync wallet to Zerion app via QR code | `zerion wallet sync --wallet trading-bot` |
 | `zerion wallet sync --all` | Sync all wallets to Zerion app | `zerion wallet sync --all` |

--- a/skills/zerion/SKILL.md
+++ b/skills/zerion/SKILL.md
@@ -74,7 +74,7 @@ Before executing any capability below, **Read the matching file** for the full c
 | Wallet analysis: portfolio, positions, history, PnL, watchlist | `capabilities/analyze.md` |
 | On-chain trading: swap, bridge, send | `capabilities/trading.md` |
 | Off-chain signing: EIP-191 messages, EIP-712 typed data | `capabilities/sign.md` |
-| Wallet management: create, import, list, fund, backup, delete | `capabilities/wallet.md` |
+| Wallet management: create, import, list, fund, backup, export-key, delete | `capabilities/wallet.md` |
 | Agent tokens + security policies for autonomous trading | `capabilities/agent-management.md` |
 | 0x Swap API v2 (direct integration, Permit2/AllowanceHolder, gasless) | `capabilities/swap-0x.md` |
 

--- a/skills/zerion/capabilities/wallet.md
+++ b/skills/zerion/capabilities/wallet.md
@@ -19,6 +19,7 @@ Requires Node.js ≥ 20. For auth see the parent `SKILL.md` (Setup + Authenticat
 - "Import my wallet from a private key / mnemonic"
 - "Show my wallets" / "list deposit addresses"
 - "Back up my recovery phrase"
+- "Export the raw private key" / "give me the 0x hex key" / "give me the Phantom-format secret"
 - "Delete this wallet"
 - "Sync my wallet to the Zerion mobile app"
 
@@ -43,7 +44,7 @@ A wallet imported from a single private key holds only one chain's account:
 | Operation | Type | Notes |
 |-----------|------|-------|
 | `wallet list`, `wallet fund` | **Agent** | Read-only. Safe to invoke autonomously. |
-| `wallet create`, `wallet import`, `wallet backup`, `wallet delete`, `wallet sync` | **Manual** | Require passphrase or interactive input. Humans must run these directly — agents must not call them. |
+| `wallet create`, `wallet import`, `wallet backup`, `wallet export-key`, `wallet delete`, `wallet sync` | **Manual** | Require passphrase or interactive input. Humans must run these directly — agents must not call them. |
 
 ## Read-only — agents may invoke freely
 
@@ -69,6 +70,13 @@ zerion wallet import --name <name> --mnemonic
 
 # Export the recovery phrase (passphrase required)
 zerion wallet backup --wallet <name>
+
+# Export raw private key(s) derived from the mnemonic (passphrase required)
+# Output goes to stderr only — same safety stance as `wallet backup`.
+zerion wallet export-key --wallet <name>                       # both chains, derivation index 0
+zerion wallet export-key --wallet <name> --chain evm           # EVM only — m/44'/60'/0'/0/0, 0x hex
+zerion wallet export-key --wallet <name> --chain solana        # Solana only — m/44'/501'/0'/0', base58 (Phantom format) + 32-byte ed25519 seed
+zerion wallet export-key --wallet <name> --chain evm --index 1 # different derivation index
 
 # Permanently delete (passphrase + confirmation)
 zerion wallet delete <name>


### PR DESCRIPTION
## Summary
- `wallet export-key` shipped in 5bb9951 but docs missed the update — fixing drift
- Adds command to README wallet-management table with full flag list + example
- Adds usage block in `capabilities/wallet.md` under manual/passphrase ops, covering `--chain evm | solana | all` and `--index N`
- Updates capability index entries (`SKILL.md`, README docs map) that enumerate wallet verbs

## Test plan
- [ ] Read rendered diff on GitHub — table renders, code block valid
- [ ] Verify command names match `cli/router.js` registration
- [ ] No code touched — pure docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)