### PR TITLE
fix(skills): restore moonpay partner docs emptied by skill consolidation

### DIFF
--- a/skills/zerion/partners/moonpay-iron.md
+++ b/skills/zerion/partners/moonpay-iron.md
@@ -1,0 +1,105 @@
+
+# MoonPay Iron Fiat-to-DCA
+
+**Purpose:** Wire USD via bank transfer to an Iron virtual account (IBAN/ACH). MoonPay converts to USDC and delivers to your wallet. Combine with Zerion trading to auto-deploy into any token on a schedule.
+
+## Key Commands
+
+- `mp virtual-account retrieve` — Check Iron account status
+- `mp virtual-account create` — Create a new virtual account (requires KYC)
+- `mp virtual-account onramp create` — Get IBAN/ACH deposit details
+- `mp virtual-account transaction list` — Monitor incoming deposits
+- `zerion swap usdc <token> <amount>` — Deploy USDC into target after deposit lands
+
+## Requirements
+
+- MoonPay CLI: `npm i -g @moonpay/cli`
+- Zerion CLI: `npm i -g zerion-cli`
+- Completed KYC on MoonPay (required for virtual accounts)
+- Registered wallet on both CLIs
+
+## Setup
+
+### 1. Create the Iron account
+
+```bash
+mp virtual-account create
+# Completes KYC via URL — finish in browser
+
+mp virtual-account agreement list
+mp virtual-account agreement accept --contentId <id>
+```
+
+### 2. Register your wallet
+
+```bash
+# Register the wallet that will receive USDC
+mp virtual-account wallet register --wallet main --chain ethereum
+```
+
+### 3. Create the onramp and get deposit details
+
+```bash
+mp virtual-account onramp create \
+  --name "Main onramp" \
+  --fiat USD \
+  --stablecoin USDC \
+  --wallet <address> \
+  --chain ethereum
+
+mp virtual-account onramp retrieve --onrampId <id>
+```
+
+Output includes your IBAN (international wire) or ACH routing + account number (US bank). Wire from your bank to these details — Iron converts automatically to USDC.
+
+### 4. Monitor the deposit
+
+```bash
+mp virtual-account transaction list --json \
+  | jq '[.items[] | {status, fiatAmount, stablecoinAmount, createdAt}]'
+```
+
+### 5. Deploy into a position using Zerion
+
+Once USDC lands, use Zerion to execute the trade:
+
+```bash
+# Check how much USDC arrived
+zerion positions <address>
+
+# Swap USDC into ETH
+zerion swap usdc eth 500
+
+# Or bridge USDC to Arbitrum first, then swap
+zerion bridge usdc arbitrum 500
+zerion swap usdc eth 500 --chain arbitrum
+```
+
+## Manual DCA pattern
+
+Run the swap command daily to dollar-cost average:
+
+```bash
+# Deploy $71 per day for 7 days ($500 total into ETH)
+zerion swap usdc eth 71
+```
+
+Automate with cron (Linux) or launchd (macOS):
+
+```bash
+# Linux cron — 9am daily
+(crontab -l 2>/dev/null; echo '0 9 * * * zerion swap usdc eth 71 # iron-dca') | crontab -
+```
+
+## Notes
+
+- Wire transfers settle in 1–3 business days; ACH in 1 business day
+- USDC lands in your registered wallet automatically — no manual claim step
+- Iron virtual accounts are a MoonPay product (Iron.fi) — the IBAN is a real bank account number
+- Pair with `zerion analyze` before each DCA to check current price levels
+
+## Related Skills
+
+- **capabilities/trading.md** — Execute swaps and bridges after USDC lands
+- **capabilities/analyze.md** — Check portfolio and current prices before deploying
+- **partners/moonpay-onramp.md** — Card/bank purchase for smaller amounts without IBAN setup

--- a/skills/zerion/partners/moonpay-onramp.md
+++ b/skills/zerion/partners/moonpay-onramp.md
@@ -1,0 +1,93 @@
+
+# MoonPay Fiat Onramp
+
+**Purpose:** Buy crypto with a credit card or bank transfer via MoonPay CLI, then use the funded wallet with Zerion for trading and analysis.
+
+## Key Commands
+
+- `mp buy --token <token> --amount <usd> --wallet <address> --email <email>` — Purchase crypto with fiat
+- `mp token balance list --wallet <address> --chain <chain>` — Verify funds arrived
+- `mp wallet list` — View wallet addresses
+
+## Requirements
+
+- MoonPay CLI (`npm i -g @moonpay/cli`) — handles fiat-to-crypto purchases
+- Zerion CLI (`npm i -g zerion-cli`) — for on-chain analysis and trading after funding
+- Wallet address (use `zerion wallet list` or `mp wallet list`)
+
+## Workflow
+
+### 1. Confirm your wallet address
+
+```bash
+# Zerion wallet (preferred — shared EVM address)
+zerion wallet list
+
+# Or MoonPay wallet
+mp wallet list
+```
+
+### 2. Buy crypto with fiat
+
+```bash
+# Buy ETH on Ethereum mainnet with $100
+mp buy \
+  --token eth_ethereum \
+  --amount 100 \
+  --wallet <eth-address> \
+  --email <email>
+```
+
+MoonPay returns a checkout URL — complete payment in browser. Funds arrive in ~5–30 minutes depending on payment method.
+
+**Common tokens:**
+
+| Token | Symbol | Chain |
+|-------|--------|-------|
+| Ethereum | `eth_ethereum` | Ethereum |
+| Solana | `sol_solana` | Solana |
+| Polygon | `pol_polygon` | Polygon |
+| Monad | `mon_mon` | Monad |
+| USDC (Ethereum) | `usdc_ethereum` | Ethereum |
+| USDC (Solana) | `usdc_solana` | Solana |
+
+### 3. Verify funds arrived
+
+```bash
+# Check balance on Ethereum
+mp token balance list --wallet <address> --chain ethereum
+
+# Or via Zerion analyze
+zerion analyze <address>
+```
+
+### 4. Start trading with Zerion
+
+Once funded, use the full Zerion trading stack:
+
+```bash
+# Swap ETH for USDC
+zerion swap eth usdc 0.05
+
+# Bridge to another chain
+zerion bridge eth arbitrum 0.05
+
+# Full portfolio view
+zerion analyze <address>
+```
+
+## Authentication
+
+MoonPay CLI uses its own authentication — run `mp login` on first use. The wallet address is shared between CLIs (same EVM address works in both).
+
+## Common Blockers
+
+- KYC required for purchases above $150 — complete at moonpay.com
+- Bank transfers take 1–3 business days; card purchases settle in minutes
+- `--email` flag is required for fiat purchases (receipt + KYC link)
+
+## Related Skills
+
+- **capabilities/analyze.md** — Check portfolio after funding
+- **capabilities/trading.md** — Swap, bridge, and send once wallet is funded
+- **partners/moonpay-iron.md** — Wire fiat via IBAN/ACH for larger amounts

--- a/skills/zerion/partners/moonpay-predict.md
+++ b/skills/zerion/partners/moonpay-predict.md
@@ -1,0 +1,129 @@
+
+# MoonPay Prediction Markets
+
+**Purpose:** Trade on prediction markets (Polymarket, Kalshi) using MoonPay CLI. Combines market research from Zerion portfolio analysis with event-based position taking.
+
+## Key Commands
+
+- `mp prediction-market market search --query <topic>` — Find markets by keyword
+- `mp prediction-market market trending list` — Top markets by volume
+- `mp prediction-market position buy --marketId <id> --outcome <yes|no> --amount <usdc>` — Open a position
+- `mp prediction-market position list` — View open positions
+- `mp prediction-market position sell --positionId <id>` — Exit a position
+- `mp prediction-market pnl retrieve` — Profit/loss across all markets
+
+## Requirements
+
+- MoonPay CLI: `npm i -g @moonpay/cli`
+- Funded wallet on Polygon with USDC.e (Polymarket uses Polygon)
+- USDC.e address: `0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174`
+
+## Setup: Fund the Polygon wallet
+
+Polymarket requires USDC.e on Polygon. Use MoonPay to bridge or buy:
+
+```bash
+# Option A: Buy POL for gas, then bridge ETH to USDC.e
+mp buy --token pol_polygon --amount 5 --wallet <address> --email <email>
+
+mp token bridge \
+  --from-wallet main --from-chain ethereum \
+  --from-token 0x0000000000000000000000000000000000000000 \
+  --from-amount 0.01 \
+  --to-chain polygon \
+  --to-token 0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174
+
+# Option B: Buy POL for gas directly + buy USDC on Polygon
+mp buy --token usdc_polygon --amount 50 --wallet <address> --email <email>
+```
+
+Verify:
+
+```bash
+mp token balance list --wallet <address> --chain polygon
+```
+
+## Trading workflow
+
+### 1. Find a market
+
+```bash
+# Search by topic
+mp prediction-market market search --query "bitcoin ETF"
+
+# Or browse trending
+mp prediction-market market trending list --limit 10
+```
+
+### 2. Check market details
+
+```bash
+mp prediction-market market price retrieve --marketId <id>
+mp prediction-market market price-history list --marketId <id>
+```
+
+### 3. Open a position
+
+```bash
+# Buy YES on a market with $20 USDC
+mp prediction-market position buy \
+  --marketId <id> \
+  --outcome yes \
+  --amount 20
+
+# Buy NO
+mp prediction-market position buy \
+  --marketId <id> \
+  --outcome no \
+  --amount 20
+```
+
+### 4. Monitor and close
+
+```bash
+# View all open positions
+mp prediction-market position list
+
+# View P&L
+mp prediction-market pnl retrieve
+
+# Sell a position early
+mp prediction-market position sell --positionId <id>
+
+# Redeem after market resolves
+mp prediction-market position redeem --positionId <id>
+```
+
+## Combining with Zerion analysis
+
+Use Zerion's on-chain data to inform macro market calls:
+
+```bash
+# Check ETH whale flows before betting on price outcomes
+zerion history <whale-address>
+
+# Check DeFi TVL trends before markets that depend on protocol health
+zerion positions <defi-protocol-address>
+
+# Then place a prediction market bet based on the on-chain signal
+mp prediction-market position buy --marketId <eth-price-market-id> --outcome yes --amount 25
+```
+
+## Common Blockers
+
+- Gas required: keep at least $3–5 POL in the wallet for transaction fees
+- Market liquidity: check `market price retrieve` — low-liquidity markets have wide spreads
+- Position limits: some markets cap individual position size
+- Resolution delay: markets resolve after the event; redemption is available after resolution
+
+## Notes
+
+- Polymarket runs on Polygon — all positions are on-chain and non-custodial
+- USDC.e (`0x2791...`) is different from native USDC — Polymarket uses USDC.e specifically
+- P&L reflects unrealized gains; positions only settle to final value at market resolution
+
+## Related Skills
+
+- **capabilities/analyze.md** — On-chain research to inform market predictions
+- **partners/moonpay-onramp.md** — Fund the wallet with fiat first
+- **capabilities/trading.md** — Move profits back to Ethereum after positions close


### PR DESCRIPTION
PR #86 moved partner skills into skills/zerion/partners/ but the three moonpay files landed as 0-byte stubs — content from the old zerion-moonpay-{onramp,iron,predict}/SKILL.md was dropped in the move.

Restore bodies from pre-consolidation commit (257ebe0^) with the same migration transform applied to other partners: frontmatter stripped, Related Skills refs rewritten to capabilities/*.md and partners/*.md paths.