### PR TITLE
ci: publish prerelease builds to npm under the `next` dist-tag

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -1,0 +1,43 @@
+name: Publish next
+
+on:
+  push:
+    branches: [main]
+  # Allows publishing a prerelease from any branch via the Actions UI
+  workflow_dispatch: {}
+
+# Serialize runs so a slow older build can't move the `next` tag past a newer one
+concurrency:
+  group: publish-next
+  cancel-in-progress: false
+
+jobs:
+  publish-next:
+    # Skip release-please's own release commits — those publish `latest` via release-please.yml
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore(main): release') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+
+      - run: npm test
+
+      - name: Set prerelease version
+        # Bump patch so the prerelease sorts above the current stable release,
+        # e.g. 1.5.0 -> 1.5.1-next.20260714093000.g325093a
+        run: |
+          BASE=$(node -p "const v = require('./package.json').version.split('.'); v[2] = Number(v[2]) + 1; v.join('.')")
+          npm version --no-git-tag-version "${BASE}-next.$(date -u +%Y%m%d%H%M%S).g${GITHUB_SHA::7}"
+
+      - run: npm publish --provenance --tag next
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -442,6 +442,33 @@ To force a specific version, add `Release-As: 2.0.0` in a commit message body.
 - `.release-please-manifest.json` tracks the current version
 - `.github/workflows/release-please.yml` handles release PR creation and npm publish
 - `.github/workflows/test.yml` runs tests on PRs and pushes to main
+- `.github/workflows/publish-next.yml` publishes prereleases to the `next` dist-tag (see below)
+
+### Prerelease channel (`@next`)
+
+Every push to `main` (except release commits) publishes a prerelease to npm under the `next` dist-tag, e.g. `1.5.1-next.20260714093000.g325093a`. Regular users are unaffected: `npm install zerion-cli` keeps resolving the `latest` tag, which only moves when a release-please release PR is merged.
+
+To try the latest merged-but-unreleased work:
+
+```bash
+npx zerion-cli@next --help
+# or
+npm install -g zerion-cli@next
+```
+
+To test an unmerged branch, install straight from git — no publish needed:
+
+```bash
+npm install -g github:zeriontech/zerion-ai#<branch>
+```
+
+A prerelease can also be published from any branch manually via the **Publish next** workflow in the Actions tab (`workflow_dispatch`).
+
+If a `next` build turns out broken, point the tag back at a known-good version:
+
+```bash
+npm dist-tag add zerion-cli@<version> next
+```
 
 ## Resources
 


### PR DESCRIPTION
## What

Adds a QA/prerelease channel for the CLI so teammates can try merged-but-unreleased improvements without touching what regular users install.

- **New workflow `.github/workflows/publish-next.yml`** — on every push to `main` (skipping release-please's own `chore(main): release` commits) it runs tests, bumps to a unique prerelease version like `1.5.1-next.20260714093000.g325093a`, and runs `npm publish --provenance --tag next`. The `--tag next` flag means the `latest` dist-tag never moves — only merging the release-please PR promotes a real release.
- **`workflow_dispatch`** — a prerelease can also be published manually from any branch via the Actions tab.
- **README** — documents the `@next` channel, git-installing unmerged branches (`npm i -g github:zeriontech/zerion-ai#<branch>`), and how to roll the `next` tag back to a known-good version with `npm dist-tag add`.

## QA flow this enables

1. Merge PRs to `main` → each merge publishes to `@next`
2. Teammates test with `npx zerion-cli@next` / `npm i -g zerion-cli@next`
3. When solid, merge the release-please PR → publishes to `latest` for everyone

## Notes

- Uses the existing `NPM_TOKEN` secret (same package, different dist-tag).
- The prerelease version bumps patch over the current stable so it sorts above it in semver; the `g` prefix on the SHA avoids invalid all-digit-with-leading-zero prerelease identifiers.
- A `concurrency` group serializes runs so an older slow build can't move the `next` tag past a newer one.
- Old `-next.*` versions accumulate on npm harmlessly; npm forbids republishing versions so no cleanup is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)