### PR TITLE
WLT-1959: refresh SKILL.md supported-chains list from live catalog

### DIFF
--- a/cli/commands/wallet/sign-message.js
+++ b/cli/commands/wallet/sign-message.js
@@ -12,7 +12,8 @@ import {
   reportMessageHandoff,
 } from "../../utils/web-app/handoff.js";
 import { solanaMessageVerifier } from "../../utils/chain/solana-handoff.js";
-import { toCaip2, SUPPORTED_CHAINS, isSolana } from "../../utils/chain/registry.js";
+import { isSolana } from "../../utils/chain/registry.js";
+import { resolveSigningChainAsync } from "../../utils/common/validate.js";
 
 export default async function walletSignMessage(args, flags) {
   const walletName = flags.wallet || getConfigValue("defaultWallet");
@@ -41,12 +42,16 @@ export default async function walletSignMessage(args, flags) {
     process.exit(1);
   }
 
-  if (!SUPPORTED_CHAINS.includes(chain)) {
-    printError("invalid_chain", `Unsupported chain "${chain}"`, {
-      suggestion: `Supported: ${SUPPORTED_CHAINS.join(", ")}`,
+  // Validate against the live catalog (not the static 14-chain registry) so any
+  // chain Zerion supports can be signed for. `caip2` is reused at signing time.
+  const chainCheck = await resolveSigningChainAsync(chain);
+  if (chainCheck.error) {
+    printError(chainCheck.error.code, chainCheck.error.message, {
+      suggestion: chainCheck.error.suggestion,
     });
     process.exit(1);
   }
+  const caip2 = chainCheck.caip2;
 
   // Resolve the wallet BEFORE prompting for agent-token setup, so a typo'd
   // --wallet doesn't drag the user through token creation just to fail.
@@ -88,7 +93,6 @@ export default async function walletSignMessage(args, flags) {
   const passphrase = await requireAgentToken("for signing", walletName);
 
   try {
-    const caip2 = toCaip2(chain);
     const result = ows.signMessage(walletName, message, passphrase, encoding, caip2);
 
     print({

--- a/cli/commands/wallet/sign-typed-data.js
+++ b/cli/commands/wallet/sign-typed-data.js
@@ -11,7 +11,7 @@ import {
   signMessageViaWebApp,
   reportMessageHandoff,
 } from "../../utils/web-app/handoff.js";
-import { toCaip2, SUPPORTED_CHAINS } from "../../utils/chain/registry.js";
+import { resolveSigningChainAsync } from "../../utils/common/validate.js";
 
 /**
  * Read EIP-712 typed data JSON from one of: --data '<json>', --file <path>, or stdin.
@@ -56,12 +56,16 @@ export default async function walletSignTypedData(args, flags) {
     process.exit(1);
   }
 
-  if (!SUPPORTED_CHAINS.includes(chain)) {
-    printError("invalid_chain", `Unsupported chain "${chain}"`, {
-      suggestion: `Supported: ${SUPPORTED_CHAINS.filter((c) => c !== "solana").join(", ")}`,
+  // Validate against the live catalog (not the static 14-chain registry) so any
+  // EVM chain Zerion supports can be signed for. `caip2` is reused at signing time.
+  const chainCheck = await resolveSigningChainAsync(chain);
+  if (chainCheck.error) {
+    printError(chainCheck.error.code, chainCheck.error.message, {
+      suggestion: chainCheck.error.suggestion,
     });
     process.exit(1);
   }
+  const caip2 = chainCheck.caip2;
 
   const typedDataJson = await resolveTypedData(flags, args);
   if (!typedDataJson || !typedDataJson.trim()) {
@@ -122,8 +126,6 @@ export default async function walletSignTypedData(args, flags) {
   const passphrase = await requireAgentToken("for signing", walletName);
 
   try {
-    const caip2 = toCaip2(chain);
-
     // Re-serialize to normalize whitespace before handing to OWS
     const canonical = JSON.stringify(parsed);
     const result = ows.signTypedData(walletName, canonical, passphrase, caip2);

--- a/cli/tests/unit/cli/utils/common/validate.test.mjs
+++ b/cli/tests/unit/cli/utils/common/validate.test.mjs
@@ -1,12 +1,14 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { describe, it, after } from "node:test";
 import {
   validateChain,
   validatePositions,
   resolvePositionFilter,
+  resolveSigningChainAsync,
   CHAIN_IDS,
   POSITION_FILTERS,
 } from "#zerion/utils/common/validate.js";
+import { __setCatalogForTests } from "#zerion/utils/chain/catalog.js";
 
 describe("validateChain", () => {
   it("returns null for each valid chain", () => {
@@ -98,5 +100,56 @@ describe("CHAIN_IDS", () => {
     for (const chain of ["ethereum", "base", "arbitrum", "solana", "polygon"]) {
       assert.ok(CHAIN_IDS.has(chain), `Missing chain: ${chain}`);
     }
+  });
+});
+
+describe("resolveSigningChainAsync", () => {
+  // Inject a fixture catalog so resolution doesn't hit the network. Includes a
+  // chain outside the static 14-chain registry (robinhood) to prove the guard
+  // now follows the live catalog, and a catalog entry with no CAIP-2.
+  const FIXTURE = new Map([
+    ["ethereum", { id: "ethereum", caip2: "eip155:1", chainIdNum: 1 }],
+    ["robinhood", { id: "robinhood", caip2: "eip155:42161000", chainIdNum: 42161000 }],
+    ["nocaip", { id: "nocaip", caip2: null, chainIdNum: null }],
+  ]);
+  __setCatalogForTests(FIXTURE);
+
+  after(() => __setCatalogForTests(null));
+
+  it("resolves a chain in the live catalog to its CAIP-2, no error", async () => {
+    const result = await resolveSigningChainAsync("ethereum");
+    assert.equal(result.error, undefined);
+    assert.equal(result.caip2, "eip155:1");
+  });
+
+  it("resolves a chain outside the static 14-chain registry (robinhood)", async () => {
+    const result = await resolveSigningChainAsync("robinhood");
+    assert.equal(result.error, undefined);
+    assert.equal(result.caip2, "eip155:42161000");
+  });
+
+  it("keeps Solana's static ed25519 network id without hitting the catalog", async () => {
+    const result = await resolveSigningChainAsync("solana");
+    assert.equal(result.error, undefined);
+    assert.match(result.caip2, /^solana:/);
+  });
+
+  it("errors for a chain not in the catalog", async () => {
+    const result = await resolveSigningChainAsync("madeupchain");
+    assert.equal(result.caip2, undefined);
+    assert.equal(result.error.code, "unsupported_chain");
+    assert.match(result.error.message, /madeupchain/);
+    assert.match(result.error.suggestion, /zerion chains/);
+  });
+
+  it("errors for a catalog chain that carries no CAIP-2", async () => {
+    const result = await resolveSigningChainAsync("nocaip");
+    assert.equal(result.error.code, "unsupported_chain");
+  });
+
+  it("returns a null CAIP-2 for a falsy chain (no validation)", async () => {
+    const result = await resolveSigningChainAsync(undefined);
+    assert.equal(result.error, undefined);
+    assert.equal(result.caip2, null);
   });
 });

--- a/cli/utils/common/validate.js
+++ b/cli/utils/common/validate.js
@@ -7,7 +7,7 @@
  * supports for swap/bridge/send works without a code change here).
  */
 
-import { SUPPORTED_CHAINS } from "../chain/registry.js";
+import { SUPPORTED_CHAINS, isSolana, toCaip2 } from "../chain/registry.js";
 import { resolveChain, listTradingChainIds, listBridgeChainIds, listSendingChainIds } from "../chain/catalog.js";
 
 export const CHAIN_IDS = new Set(SUPPORTED_CHAINS);
@@ -112,4 +112,29 @@ export async function validateTradingChainAsync(chain, kind = "trade") {
   }
 
   return { config };
+}
+
+// Resolve a chain to its CAIP-2 id for off-chain signing (EIP-191 personal_sign
+// / EIP-712 typed data), validating against the live `/chains/` catalog rather
+// than the static registry — so any chain Zerion knows can be signed for
+// without a code change here. Off-chain signing needs no trading/bridge/send
+// capability, only a known chain that carries a CAIP-2, so this deliberately
+// does NOT check capability flags. Solana keeps its static ed25519 network id
+// (it has no eip155 id in the EVM catalog). Returns `{ error, caip2 }` — exactly
+// one is set.
+export async function resolveSigningChainAsync(chain) {
+  if (!chain) return { caip2: null };
+  if (isSolana(chain)) return { caip2: toCaip2("solana") };
+
+  const config = await resolveChain(chain);
+  if (!config || !config.caip2) {
+    return {
+      error: {
+        code: "unsupported_chain",
+        message: `Unsupported chain '${chain}'.`,
+        suggestion: "Run `zerion chains` for the live list of supported chains and their capabilities.",
+      },
+    };
+  }
+  return { caip2: config.caip2 };
 }

--- a/skills/zerion/SKILL.md
+++ b/skills/zerion/SKILL.md
@@ -128,7 +128,11 @@ Flags: `--json` (default), `--pretty` (auto-enabled for TTY), `--quiet`.
 
 ## Supported chains
 
-`ethereum`, `base`, `arbitrum`, `optimism`, `polygon`, `binance-smart-chain`, `avalanche`, `gnosis`, `scroll`, `linea`, `zksync-era`, `zora`, `blast`, `solana`.
+Zerion supports **60+ chains**, and adds more over time. Per-chain capabilities differ — some support swap **and** bridge **and** send, others only sending or reads — so `zerion chains` (or `zerion chains --json` for the `supportsTrading` / `supportsBridge` / `supportsSending` flags) is the **source of truth**.
+
+> ⚠️ **Never tell a user a chain is unsupported based on the static list below.** It is a snapshot and goes stale as chains are added. If a chain you need isn't listed here — or you're unsure whether it supports a given action — run `zerion chains` and check the flags **instead of stopping**. (This exact list, at 14 chains, once caused an agent to wrongly report that `robinhood`, `monad`, `hyperevm`, and ~20 other live chains "cannot be moved by Zerion.")
+
+Snapshot of the live catalog (verify with `zerion chains`): `0g`, `abstract`, `ape`, `arbitrum`, `astar-zkevm`, `aurora`, `avalanche`, `base`, `berachain`, `binance-smart-chain`, `blast`, `bob`, `celo`, `cronos-zkevm`, `cyber`, `degen`, `ethereum`, `fantom`, `fraxtal`, `gravity-alpha`, `hyperevm`, `ink`, `katana`, `lens`, `linea`, `lisk`, `manta-pacific`, `mantle`, `megaeth`, `metis-andromeda`, `mode`, `monad`, `okbchain`, `opbnb`, `optimism`, `plasma`, `polygon`, `polygon-zkevm`, `polynomial`, `rari`, `re-al`, `redstone`, `robinhood`, `ronin`, `scroll`, `sei`, `solana`, `somnia`, `soneium`, `sonic`, `swellchain`, `taiko`, `tempo`, `tomochain`, `tron`, `unichain`, `wonder`, `world`, `xdai`, `xinfin-xdc`, `zero`, `zkcandy`, `zklink-nova`, `zksync-era`, `zora`.
 
 Solana supports same-chain swaps and bidirectional bridging to/from EVM chains. Cross-format bridges (Solana ↔ EVM) require an explicit destination via `--to-wallet <name>` or `--to-address <addr>` matching the target chain's format.
 


### PR DESCRIPTION
## Summary

The `zerion` skill's `SKILL.md` hardcoded a **14-chain** "Supported chains" list. An agent relied on it and told a user that ~$18.4k across 20+ live chains — including `robinhood` (which actually supports trade **and** bridge **and** send) — "cannot be moved by Zerion." The live `zerion chains` catalog reports **65 chains**.

### 1. Docs — refresh the supported-chains list (`skills/zerion/SKILL.md`)
- Refreshed the "Supported chains" list from the live catalog (65 chains), using the **real API chain IDs** the CLI accepts (e.g. `xdai` instead of the registry alias `gnosis`).
- Framed the list as a **snapshot** and named `zerion chains` (and `--json` capability flags) as the source of truth.
- Added an explicit note: **never declare a chain unsupported based on the static list** — run `zerion chains` and check `supportsTrading` / `supportsBridge` / `supportsSending` **instead of stopping**.

### 2. Code — make signing resolve chains from the live catalog (review follow-up)
The trading paths (`swap`/`bridge`/`send`/`consolidate`) already resolve chains against the live `/chains/` catalog via `validateTradingChainAsync` — verified, unchanged. But `sign-message` and `sign-typed-data` still gated on the static 14-chain registry (`SUPPORTED_CHAINS.includes`) and derived CAIP-2 via `toCaip2` (which only knows those 14), so a valid chain like `robinhood`/`monad` was wrongly rejected for off-chain signing.
- Added `resolveSigningChainAsync` (`cli/utils/common/validate.js`): fetch-then-decide against the live catalog, CAIP-2 derived from the catalog. Off-chain signing needs no trading capability, so it only checks the chain is known and carries a CAIP-2; Solana keeps its static ed25519 network id.
- Switched both signing commands to it; unknown chains now error with a `zerion chains` hint.

### Still out of scope
The analytics reads (`overview`/`positions`, sync `validateChain`) remain on the static list — read-only and low-risk.

Closes WLT-1959

## Test plan
- `npm test` → **383 pass / 0 fail** (added 6 cases for `resolveSigningChainAsync` via the catalog test seam).
- `zerion chains` confirms the live catalog (65 chains); `robinhood` reports trade/bridge/send = true.
- `sign-message`/`sign-typed-data --chain monad|robinhood` → now pass the chain gate; `--chain notarealchain` → `unsupported_chain`; `--chain solana` → message signs, typed-data stays `evm_only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)