### PR TITLE
fix(cli): mask private key and mnemonic input on wallet import (WLT-2075)

### DIFF
--- a/cli/commands/wallet/import.js
+++ b/cli/commands/wallet/import.js
@@ -35,8 +35,8 @@ export default async function walletImport(args, flags) {
     let wallet;
     let origin;
 
-    // Key material is masked for the same reason the passphrase is: it is read
-    // in front of whoever can see the screen (and shared screens / recordings).
+    // Key material is hidden while typing for the same reason the passphrase is:
+    // it is entered in front of whoever can see the screen (or the recording).
     if (hasEvmKey) {
       const key = await readSecret("Enter EVM private key (hex): ", { mask: true });
       wallet = ows.importFromKey(name, key, passphrase, "evm");

--- a/cli/commands/wallet/import.js
+++ b/cli/commands/wallet/import.js
@@ -35,16 +35,20 @@ export default async function walletImport(args, flags) {
     let wallet;
     let origin;
 
+    // Key material is masked for the same reason the passphrase is: it is read
+    // in front of whoever can see the screen (and shared screens / recordings).
     if (hasEvmKey) {
-      const key = await readSecret("Enter EVM private key (hex): ");
+      const key = await readSecret("Enter EVM private key (hex): ", { mask: true });
       wallet = ows.importFromKey(name, key, passphrase, "evm");
       origin = WALLET_ORIGIN.EVM_KEY;
     } else if (hasSolKey) {
-      const key = await readSecret("Enter Solana private key (base58, hex, or byte array): ");
+      const key = await readSecret("Enter Solana private key (base58, hex, or byte array): ", {
+        mask: true,
+      });
       wallet = ows.importFromKey(name, key, passphrase, "solana");
       origin = WALLET_ORIGIN.SOL_KEY;
     } else {
-      const mnemonic = await readSecret("Enter mnemonic phrase: ");
+      const mnemonic = await readSecret("Enter mnemonic phrase: ", { mask: true });
       wallet = ows.importFromMnemonic(name, mnemonic, passphrase);
       origin = WALLET_ORIGIN.MNEMONIC;
     }

--- a/cli/tests/unit/cli/utils/common/prompt.test.mjs
+++ b/cli/tests/unit/cli/utils/common/prompt.test.mjs
@@ -4,7 +4,7 @@ import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { PassThrough } from "node:stream";
-import { readSecret, readPassphraseFromFile } from "#zerion/utils/common/prompt.js";
+import { readSecret, readPassphrase, readPassphraseFromFile } from "#zerion/utils/common/prompt.js";
 
 const isWindows = process.platform === "win32";
 
@@ -80,6 +80,7 @@ describe("readSecret masked input", () => {
   const BACKSPACE = "\u007F";
   const CTRL_C = "\u0003";
   const CTRL_D = "\u0004";
+  const CTRL_U = "\u0015"; // kill line
   const ESC = "\u001B";
 
   let realStdin;
@@ -203,5 +204,94 @@ describe("readSecret masked input", () => {
     const pending = readSecret(PROMPT, { mask: true });
     stream.write(`${KEY}\n`);
     assert.equal(await pending, KEY);
+  });
+
+  it("clears the whole line on Ctrl-U (kill line)", async () => {
+    const { value } = await prompt(["wrong", CTRL_U, "right\r"]);
+    assert.equal(value, "right");
+  });
+
+  // `wallet import` runs prompts back to back (passphrase, confirm, key);
+  // each one must get a fresh interface on the same stdin without dropping input.
+  it("keeps two sequential prompts on the same stdin separate", async () => {
+    const stream = fakeTty();
+    withStdin(stream);
+
+    let written = "";
+    process.stderr.write = (str) => {
+      written += str;
+      return true;
+    };
+
+    const first = readSecret("Enter passphrase: ", { mask: true });
+    stream.write("hunter2\r");
+    assert.equal(await first, "hunter2");
+
+    const second = readSecret(PROMPT, { mask: true });
+    stream.write(`${KEY}\r`);
+    assert.equal(await second, KEY);
+
+    process.stderr.write = realWrite;
+    assert.equal(written, `Enter passphrase: \n${PROMPT}\n`);
+  });
+
+  // A terminal paste can end in \r\n; the \r submits, and the leftover \n must
+  // not submit the NEXT prompt as an empty line.
+  it("does not leak the LF of a CRLF submit into the next prompt", async () => {
+    const stream = fakeTty();
+    withStdin(stream);
+    process.stderr.write = () => true;
+
+    const first = readSecret(PROMPT, { mask: true });
+    stream.write("first-secret\r\n");
+    assert.equal(await first, "first-secret");
+
+    const second = readSecret(PROMPT, { mask: true });
+    stream.write("second-secret\r");
+    assert.equal(await second, "second-secret");
+
+    process.stderr.write = realWrite;
+  });
+});
+
+describe("readPassphrase confirm flow", () => {
+  let realStdin;
+  let realWrite;
+
+  before(() => {
+    realStdin = process.stdin;
+    realWrite = process.stderr.write;
+  });
+
+  after(() => {
+    Object.defineProperty(process, "stdin", { value: realStdin, configurable: true });
+    process.stderr.write = realWrite;
+  });
+
+  it("retries on mismatch and never echoes either attempt", async () => {
+    const stream = new PassThrough();
+    stream.isTTY = true;
+    stream.setRawMode = () => stream;
+    Object.defineProperty(process, "stdin", { value: stream, configurable: true });
+
+    // Reply to each prompt as it appears: first pair mismatches, second matches.
+    const replies = ["first-try\r", "does-not-match\r", "correct horse\r", "correct horse\r"];
+    let written = "";
+    process.stderr.write = (str) => {
+      written += str;
+      if (str.endsWith("passphrase: ")) {
+        const reply = replies.shift();
+        if (reply) process.nextTick(() => stream.write(reply));
+      }
+      return true;
+    };
+
+    const value = await readPassphrase({ confirm: true });
+    process.stderr.write = realWrite;
+
+    assert.equal(value, "correct horse");
+    assert.match(written, /do not match/i);
+    assert.ok(!written.includes("first-try"), "expected no echo of the first attempt");
+    assert.ok(!written.includes("correct horse"), "expected no echo of the passphrase");
   });
 });

--- a/cli/tests/unit/cli/utils/common/prompt.test.mjs
+++ b/cli/tests/unit/cli/utils/common/prompt.test.mjs
@@ -3,7 +3,7 @@ import { describe, it, before, after } from "node:test";
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { readPassphraseFromFile } from "#zerion/utils/common/prompt.js";
+import { applyMaskedChunk, readPassphraseFromFile } from "#zerion/utils/common/prompt.js";
 
 const isWindows = process.platform === "win32";
 
@@ -70,5 +70,98 @@ describe("readPassphraseFromFile", () => {
     writeFileSync(path, "", { mode: 0o600 });
     chmodSync(path, 0o600);
     assert.throws(() => readPassphraseFromFile(path), /empty/i);
+  });
+});
+
+describe("applyMaskedChunk", () => {
+  const KEY = "0x0ee04d8466aa0f5a05d3ab5a3f9f1e1c2b3a49586d7c8b9a0f1e2d3c4b5a6978";
+
+  it("masks a typed character one-for-one", () => {
+    assert.deepEqual(applyMaskedChunk("", "a"), {
+      value: "a",
+      echo: "*",
+      done: false,
+      abort: false,
+    });
+  });
+
+  it("masks every character of a pasted key, not just the chunk", () => {
+    const step = applyMaskedChunk("", KEY);
+    assert.equal(step.value, KEY);
+    assert.equal(step.echo, "*".repeat(KEY.length));
+    assert.equal(step.done, false);
+  });
+
+  it("submits when a pasted key arrives with a trailing newline", () => {
+    const step = applyMaskedChunk("", `${KEY}\n`);
+    assert.equal(step.value, KEY);
+    assert.equal(step.done, true);
+    assert.equal(step.echo, "*".repeat(KEY.length));
+  });
+
+  it("submits on CRLF without keeping the CR", () => {
+    const step = applyMaskedChunk("0xab", "cd\r\n");
+    assert.equal(step.value, "0xabcd");
+    assert.equal(step.done, true);
+  });
+
+  it("drops anything after the terminator so it cannot leak into the next prompt", () => {
+    const step = applyMaskedChunk("", "secret\nleftover");
+    assert.equal(step.value, "secret");
+    assert.equal(step.echo, "*".repeat(6));
+    assert.equal(step.done, true);
+  });
+
+  it("submits on Ctrl-D", () => {
+    const step = applyMaskedChunk("abc", "\u0004");
+    assert.equal(step.value, "abc");
+    assert.equal(step.done, true);
+  });
+
+  it("aborts on Ctrl-C", () => {
+    const step = applyMaskedChunk("abc", "\u0003");
+    assert.equal(step.abort, true);
+    assert.equal(step.done, false);
+  });
+
+  it("erases the last character on backspace", () => {
+    const step = applyMaskedChunk("abc", "\u007F");
+    assert.equal(step.value, "ab");
+    assert.equal(step.echo, "\b \b");
+  });
+
+  it("ignores backspace on an empty buffer", () => {
+    assert.deepEqual(applyMaskedChunk("", "\u007F"), {
+      value: "",
+      echo: "",
+      done: false,
+      abort: false,
+    });
+  });
+
+  it("strips bracketed-paste markers", () => {
+    const step = applyMaskedChunk("", `\u001B[200~${KEY}\u001B[201~`);
+    assert.equal(step.value, KEY);
+    assert.equal(step.echo, "*".repeat(KEY.length));
+  });
+
+  it("ignores arrow keys instead of masking them as input", () => {
+    const step = applyMaskedChunk("ab", "\u001B[Ac");
+    assert.equal(step.value, "abc");
+    assert.equal(step.echo, "*");
+  });
+
+  it("ignores other control characters", () => {
+    const step = applyMaskedChunk("", "\u0001a\u0002");
+    assert.equal(step.value, "a");
+    assert.equal(step.echo, "*");
+  });
+
+  it("keeps spaces so a mnemonic survives", () => {
+    const words = "test test test test test test test test test test test junk";
+    const step = applyMaskedChunk("", `${words}\r`);
+    assert.equal(step.value, words);
+    assert.equal(step.done, true);
+    assert.equal(step.echo, "*".repeat(words.length));
   });
 });

--- a/cli/tests/unit/cli/utils/common/prompt.test.mjs
+++ b/cli/tests/unit/cli/utils/common/prompt.test.mjs
@@ -3,7 +3,8 @@ import { describe, it, before, after } from "node:test";
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { applyMaskedChunk, readPassphraseFromFile } from "#zerion/utils/common/prompt.js";
+import { PassThrough } from "node:stream";
+import { readSecret, readPassphraseFromFile } from "#zerion/utils/common/prompt.js";
 
 const isWindows = process.platform === "win32";
 
@@ -73,95 +74,134 @@ describe("readPassphraseFromFile", () => {
   });
 });
 
-describe("applyMaskedChunk", () => {
+describe("readSecret masked input", () => {
   const KEY = "0x0ee04d8466aa0f5a05d3ab5a3f9f1e1c2b3a49586d7c8b9a0f1e2d3c4b5a6978";
+  const PROMPT = "Enter EVM private key (hex): ";
+  const BACKSPACE = "\u007F";
+  const CTRL_C = "\u0003";
+  const CTRL_D = "\u0004";
+  const ESC = "\u001B";
 
-  it("masks a typed character one-for-one", () => {
-    assert.deepEqual(applyMaskedChunk("", "a"), {
-      value: "a",
-      echo: "*",
-      done: false,
-      abort: false,
-    });
+  let realStdin;
+  let realWrite;
+  let realExit;
+
+  // readline in terminal mode only needs isTTY + setRawMode, so a PassThrough
+  // standing in for stdin exercises the real prompt without needing a pty.
+  function fakeTty() {
+    const stream = new PassThrough();
+    stream.isTTY = true;
+    stream.setRawMode = () => stream;
+    return stream;
+  }
+
+  function withStdin(stream) {
+    Object.defineProperty(process, "stdin", { value: stream, configurable: true });
+  }
+
+  before(() => {
+    realStdin = process.stdin;
+    realWrite = process.stderr.write;
+    realExit = process.exit;
   });
 
-  it("masks every character of a pasted key, not just the chunk", () => {
-    const step = applyMaskedChunk("", KEY);
-    assert.equal(step.value, KEY);
-    assert.equal(step.echo, "*".repeat(KEY.length));
-    assert.equal(step.done, false);
+  after(() => {
+    withStdin(realStdin);
+    process.stderr.write = realWrite;
+    process.exit = realExit;
   });
 
-  it("submits when a pasted key arrives with a trailing newline", () => {
-    const step = applyMaskedChunk("", `${KEY}\n`);
-    assert.equal(step.value, KEY);
-    assert.equal(step.done, true);
-    assert.equal(step.echo, "*".repeat(KEY.length));
+  /**
+   * Drive one masked prompt: returns the resolved secret plus everything that
+   * reached the screen, so a test can assert the secret was never echoed.
+   */
+  async function prompt(chunks) {
+    const stream = fakeTty();
+    withStdin(stream);
+
+    let written = "";
+    process.stderr.write = (str) => {
+      written += str;
+      return true;
+    };
+
+    const pending = readSecret(PROMPT, { mask: true });
+    for (const chunk of chunks) stream.write(chunk);
+    const value = await pending;
+
+    process.stderr.write = realWrite;
+    return { value, written };
+  }
+
+  it("returns the typed secret without echoing it", async () => {
+    const { value, written } = await prompt(["s", "e", "c", "r", "e", "t", "\r"]);
+    assert.equal(value, "secret");
+    assert.equal(written, `${PROMPT}\n`);
   });
 
-  it("submits on CRLF without keeping the CR", () => {
-    const step = applyMaskedChunk("0xab", "cd\r\n");
-    assert.equal(step.value, "0xabcd");
-    assert.equal(step.done, true);
+  it("keeps a key pasted as one chunk intact and off the screen", async () => {
+    const { value, written } = await prompt([`${KEY}\n`]);
+    assert.equal(value, KEY);
+    assert.equal(written, `${PROMPT}\n`);
   });
 
-  it("drops anything after the terminator so it cannot leak into the next prompt", () => {
-    const step = applyMaskedChunk("", "secret\nleftover");
-    assert.equal(step.value, "secret");
-    assert.equal(step.echo, "*".repeat(6));
-    assert.equal(step.done, true);
+  it("never echoes an asterisk or any of the secret's characters", async () => {
+    const { written } = await prompt([`${KEY}\n`]);
+    assert.ok(!written.includes("*"), "expected no asterisks");
+    assert.ok(!written.includes(KEY.slice(2, 10)), "expected no key characters");
   });
 
-  it("submits on Ctrl-D", () => {
-    const step = applyMaskedChunk("abc", "\u0004");
-    assert.equal(step.value, "abc");
-    assert.equal(step.done, true);
+  it("submits on a bare CR and on LF alike", async () => {
+    assert.equal((await prompt(["abc\r"])).value, "abc");
+    assert.equal((await prompt(["abc\n"])).value, "abc");
   });
 
-  it("aborts on Ctrl-C", () => {
-    const step = applyMaskedChunk("abc", "\u0003");
-    assert.equal(step.abort, true);
-    assert.equal(step.done, false);
+  it("erases the last character on backspace", async () => {
+    const { value } = await prompt(["0xab", BACKSPACE, "c\r"]);
+    assert.equal(value, "0xac");
   });
 
-  it("erases the last character on backspace", () => {
-    const step = applyMaskedChunk("abc", "\u007F");
-    assert.equal(step.value, "ab");
-    assert.equal(step.echo, "\b \b");
+  it("ignores backspace on an empty buffer", async () => {
+    const { value } = await prompt([BACKSPACE, "ab\r"]);
+    assert.equal(value, "ab");
   });
 
-  it("ignores backspace on an empty buffer", () => {
-    assert.deepEqual(applyMaskedChunk("", "\u007F"), {
-      value: "",
-      echo: "",
-      done: false,
-      abort: false,
-    });
+  it("strips bracketed-paste markers from a pasted key", async () => {
+    const { value } = await prompt([`${ESC}[200~${KEY}${ESC}[201~`, "\r"]);
+    assert.equal(value, KEY);
   });
 
-  it("strips bracketed-paste markers", () => {
-    const step = applyMaskedChunk("", `\u001B[200~${KEY}\u001B[201~`);
-    assert.equal(step.value, KEY);
-    assert.equal(step.echo, "*".repeat(KEY.length));
+  it("ignores arrow keys instead of taking them as input", async () => {
+    const { value } = await prompt(["ab", `${ESC}[A`, "c\r"]);
+    assert.equal(value, "abc");
   });
 
-  it("ignores arrow keys instead of masking them as input", () => {
-    const step = applyMaskedChunk("ab", "\u001B[Ac");
-    assert.equal(step.value, "abc");
-    assert.equal(step.echo, "*");
-  });
-
-  it("ignores other control characters", () => {
-    const step = applyMaskedChunk("", "\u0001a\u0002");
-    assert.equal(step.value, "a");
-    assert.equal(step.echo, "*");
-  });
-
-  it("keeps spaces so a mnemonic survives", () => {
+  it("keeps the inner spaces of a mnemonic and trims the edges", async () => {
     const words = "test test test test test test test test test test test junk";
-    const step = applyMaskedChunk("", `${words}\r`);
-    assert.equal(step.value, words);
-    assert.equal(step.done, true);
-    assert.equal(step.echo, "*".repeat(words.length));
+    const { value } = await prompt([`  ${words}  \r`]);
+    assert.equal(value, words);
+  });
+
+  it("exits 130 on Ctrl-C", async () => {
+    const codes = [];
+    process.exit = (code) => codes.push(code);
+    await prompt(["abc", CTRL_C]);
+    process.exit = realExit;
+    assert.deepEqual(codes, [130]);
+  });
+
+  it("resolves empty on Ctrl-D at an empty prompt rather than hanging", async () => {
+    const { value } = await prompt([CTRL_D]);
+    assert.equal(value, "");
+  });
+
+  it("falls back to line-buffered reads when stdin is not a TTY", async () => {
+    const stream = new PassThrough();
+    stream.isTTY = false;
+    withStdin(stream);
+
+    const pending = readSecret(PROMPT, { mask: true });
+    stream.write(`${KEY}\n`);
+    assert.equal(await pending, KEY);
   });
 });

--- a/cli/utils/common/prompt.js
+++ b/cli/utils/common/prompt.js
@@ -5,107 +5,47 @@
 import { createInterface } from "node:readline";
 import { readFileSync, statSync } from "node:fs";
 
-const ENTER = ["\n", "\r"];
-const CTRL_C = "\u0003";
-const CTRL_D = "\u0004";
-const BACKSPACE = ["\u007F", "\b"];
-const ESC = "\u001B";
-
-/**
- * Fold one raw-mode stdin chunk into the masked-input state machine.
- *
- * A chunk is not one keystroke: a paste arrives as a single multi-character
- * chunk, and pasting is how private keys and mnemonics are actually entered.
- * So every chunk is walked character by character — otherwise a pasted key
- * echoes one `*` for the whole paste and a trailing newline lands *inside*
- * the secret instead of submitting it.
- *
- * Returns the new buffer plus what to echo, and whether the caller should
- * finish (Enter/Ctrl-D) or abort (Ctrl-C). Anything after the terminator in
- * the same chunk is dropped rather than left to leak into the next prompt.
- */
-export function applyMaskedChunk(current, chunk) {
-  let value = current;
-  let echo = "";
-
-  for (let i = 0; i < chunk.length; i++) {
-    const ch = chunk[i];
-
-    if (ENTER.includes(ch) || ch === CTRL_D) {
-      return { value, echo, done: true, abort: false };
-    }
-
-    if (ch === CTRL_C) {
-      return { value, echo, done: false, abort: true };
-    }
-
-    if (BACKSPACE.includes(ch)) {
-      if (value.length > 0) {
-        value = value.slice(0, -1);
-        echo += "\b \b";
-      }
-      continue;
-    }
-
-    if (ch === ESC) {
-      // Terminal escape sequence — arrow keys, bracketed-paste markers
-      // (ESC [ 200 ~ … ESC [ 201 ~). Swallow it so it never becomes part of
-      // the secret. CSI runs until a final byte in @–~; other sequences are
-      // rare enough that dropping the ESC alone is fine.
-      if (chunk[i + 1] === "[") {
-        let j = i + 2;
-        while (j < chunk.length && !/[@-~]/.test(chunk[j])) j++;
-        i = j;
-      }
-      continue;
-    }
-
-    // Remaining control characters carry no text — never echo a `*` for them.
-    if (ch < " ") continue;
-
-    value += ch;
-    echo += "*";
-  }
-
-  return { value, echo, done: false, abort: false };
-}
-
 export function readSecret(prompt, { mask = false } = {}) {
   return new Promise((resolve) => {
     process.stderr.write(prompt);
 
-    // If masking and stdin is a TTY, use raw mode to replace each keystroke with *
+    // Hidden input, the way sudo and ssh do it: nothing is drawn while typing.
+    // readline gives this for free — `terminal: true` turns on its raw-mode line
+    // editing (pastes, backspace, arrow keys, kill-line, Ctrl-C/Ctrl-D) while a
+    // null `output` means it echoes nothing at all. Don't swap in a no-op
+    // output stream instead: readline writes its cursor/clear escapes straight
+    // to output, and the clear-to-end-of-screen one wipes the prompt away.
     if (mask && process.stdin.isTTY) {
-      let input = "";
-      process.stdin.setRawMode(true);
-      process.stdin.resume();
-      process.stdin.setEncoding("utf8");
+      const rl = createInterface({
+        input: process.stdin,
+        output: null,
+        terminal: true,
+        historySize: 0, // never keep a secret in readline's history
+      });
 
-      const restore = () => {
-        process.stdin.setRawMode(false);
-        process.stdin.pause();
-        process.stdin.removeListener("data", onData);
+      // close() re-emits `close`, so guard: without this the first resolve wins
+      // and a plain Enter would hand back "" instead of the secret.
+      let settled = false;
+      const finish = (value) => {
+        if (settled) return;
+        settled = true;
+        rl.close();
+        process.stderr.write("\n");
+        resolve(value);
       };
 
-      const onData = (chunk) => {
-        const step = applyMaskedChunk(input, chunk);
-        input = step.value;
-        if (step.echo) process.stderr.write(step.echo);
+      rl.on("line", (line) => finish(line.trim()));
 
-        if (step.abort) {
-          restore();
-          process.stderr.write("\n");
-          process.exit(130);
-        }
+      // Ctrl-D at an empty prompt closes without emitting `line`; resolve empty
+      // so the caller's own validation reports it instead of hanging forever.
+      rl.on("close", () => finish(""));
 
-        if (step.done) {
-          restore();
-          process.stderr.write("\n");
-          resolve(input.trim());
-        }
-      };
-
-      process.stdin.on("data", onData);
+      // Once something listens for SIGINT, readline stops letting Ctrl-C kill
+      // the process, so exit here — after close() has restored the terminal.
+      rl.on("SIGINT", () => {
+        finish("");
+        process.exit(130);
+      });
       return;
     }
 
@@ -117,7 +57,6 @@ export function readSecret(prompt, { mask = false } = {}) {
     });
   });
 }
-
 /**
  * Prompt for a passphrase with optional confirmation (enter twice).
  * Requires an interactive terminal — passphrase must always be entered by a human.

--- a/cli/utils/common/prompt.js
+++ b/cli/utils/common/prompt.js
@@ -5,6 +5,71 @@
 import { createInterface } from "node:readline";
 import { readFileSync, statSync } from "node:fs";
 
+const ENTER = ["\n", "\r"];
+const CTRL_C = "\u0003";
+const CTRL_D = "\u0004";
+const BACKSPACE = ["\u007F", "\b"];
+const ESC = "\u001B";
+
+/**
+ * Fold one raw-mode stdin chunk into the masked-input state machine.
+ *
+ * A chunk is not one keystroke: a paste arrives as a single multi-character
+ * chunk, and pasting is how private keys and mnemonics are actually entered.
+ * So every chunk is walked character by character — otherwise a pasted key
+ * echoes one `*` for the whole paste and a trailing newline lands *inside*
+ * the secret instead of submitting it.
+ *
+ * Returns the new buffer plus what to echo, and whether the caller should
+ * finish (Enter/Ctrl-D) or abort (Ctrl-C). Anything after the terminator in
+ * the same chunk is dropped rather than left to leak into the next prompt.
+ */
+export function applyMaskedChunk(current, chunk) {
+  let value = current;
+  let echo = "";
+
+  for (let i = 0; i < chunk.length; i++) {
+    const ch = chunk[i];
+
+    if (ENTER.includes(ch) || ch === CTRL_D) {
+      return { value, echo, done: true, abort: false };
+    }
+
+    if (ch === CTRL_C) {
+      return { value, echo, done: false, abort: true };
+    }
+
+    if (BACKSPACE.includes(ch)) {
+      if (value.length > 0) {
+        value = value.slice(0, -1);
+        echo += "\b \b";
+      }
+      continue;
+    }
+
+    if (ch === ESC) {
+      // Terminal escape sequence — arrow keys, bracketed-paste markers
+      // (ESC [ 200 ~ … ESC [ 201 ~). Swallow it so it never becomes part of
+      // the secret. CSI runs until a final byte in @–~; other sequences are
+      // rare enough that dropping the ESC alone is fine.
+      if (chunk[i + 1] === "[") {
+        let j = i + 2;
+        while (j < chunk.length && !/[@-~]/.test(chunk[j])) j++;
+        i = j;
+      }
+      continue;
+    }
+
+    // Remaining control characters carry no text — never echo a `*` for them.
+    if (ch < " ") continue;
+
+    value += ch;
+    echo += "*";
+  }
+
+  return { value, echo, done: false, abort: false };
+}
+
 export function readSecret(prompt, { mask = false } = {}) {
   return new Promise((resolve) => {
     process.stderr.write(prompt);
@@ -16,29 +81,27 @@ export function readSecret(prompt, { mask = false } = {}) {
       process.stdin.resume();
       process.stdin.setEncoding("utf8");
 
-      const onData = (ch) => {
-        if (ch === "\n" || ch === "\r" || ch === "\u0004") {
-          // Enter or Ctrl-D — done
-          process.stdin.setRawMode(false);
-          process.stdin.pause();
-          process.stdin.removeListener("data", onData);
-          process.stderr.write("\n");
-          resolve(input.trim());
-        } else if (ch === "\u0003") {
-          // Ctrl-C — abort
-          process.stdin.setRawMode(false);
-          process.stdin.pause();
+      const restore = () => {
+        process.stdin.setRawMode(false);
+        process.stdin.pause();
+        process.stdin.removeListener("data", onData);
+      };
+
+      const onData = (chunk) => {
+        const step = applyMaskedChunk(input, chunk);
+        input = step.value;
+        if (step.echo) process.stderr.write(step.echo);
+
+        if (step.abort) {
+          restore();
           process.stderr.write("\n");
           process.exit(130);
-        } else if (ch === "\u007F" || ch === "\b") {
-          // Backspace
-          if (input.length > 0) {
-            input = input.slice(0, -1);
-            process.stderr.write("\b \b");
-          }
-        } else {
-          input += ch;
-          process.stderr.write("*");
+        }
+
+        if (step.done) {
+          restore();
+          process.stderr.write("\n");
+          resolve(input.trim());
         }
       };
 


### PR DESCRIPTION
## Summary

`zerion wallet import` masked the passphrase but echoed the secret it actually imports — the EVM/Solana private key or mnemonic was printed in cleartext on screen (shoulder-surfing, shared screens, recordings, scrollback).

Nothing is drawn at all while typing now — no mask character, same as `sudo`/`ssh`.

- `readSecret`, when masking on a TTY, hands the line editing to `readline`: `terminal: true` gives its raw-mode editing (multi-character paste chunks, backspace, arrow keys, kill-line, Ctrl-C/Ctrl-D) and `output: null` makes it echo nothing. No private/undocumented API, and no custom key parsing to maintain.
- `wallet import` passes `{ mask: true }` for `--evm-key`, `--sol-key` and `--mnemonic`. The mnemonic is included deliberately — it is strictly more sensitive than a single key.
- Confirmation prompts (`Type DELETE to confirm`, `Type YES to confirm`) stay visible; `mask` remains opt-in per call site.
- Non-TTY / piped input is unchanged (no echo to hide).

Two things worth knowing, both found by running a real pty rather than reading the docs:

- A silenced-but-present output stream (the usual `rl._writeToOutput = () => {}` trick) is **not** equivalent to `output: null`. `readline` writes its cursor/clear escapes straight to `output`, bypassing `_writeToOutput`, so the first backspace emits a clear-to-end-of-screen that erases the prompt text and leaves the cursor floating.
- `rl.close()` re-emits `close`, so the `close` handler that guards against a Ctrl-D hang has to be idempotent with the `line` handler — otherwise a plain Enter resolves `""` instead of the secret.

Closes WLT-2075

## Test plan

- `npm test` — 403 pass / 0 fail. 12 tests drive `readSecret` itself through a stand-in TTY stream (`PassThrough` with `isTTY`/`setRawMode`) and assert that neither an asterisk nor any character of the secret reaches the screen: typed input, key pasted as one chunk, CR and LF, backspace, backspace on an empty buffer, bracketed-paste markers, arrow keys, mnemonic spaces preserved with edges trimmed, Ctrl-C → exit 130, Ctrl-D → resolves empty instead of hanging, and the non-TTY fallback.
- Verified under a real pty (`script -q /dev/null`): a pasted 66-char key returns intact with a blank prompt line, a 12-word mnemonic with a mid-word backspace edits correctly, two sequential prompts (passphrase + confirm) do not drop input, Ctrl-C exits 130, and piped `stdin` still reads normally.
- Manual check to run before merge: `zerion wallet import --name tmp --evm-key` in a real terminal — the key line should stay blank while typing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)