### PR TITLE
fix(cli): simplify the install command to `npx zerion-cli init` (WLT-2083)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,17 @@ CLI for [Zerion Wallet](https://zerion.io). Analyze wallets, sign, swap, and bri
 
 ## Installation
 
-Set up everything in one command (install CLI globally, configure your API key, and add skills across all detected coding agents):
+Set up everything in one command (install CLI globally, configure your API key, and add skills to your coding agents):
 
 ```bash
-npx -y zerion-cli init -y --browser
+npx zerion-cli init
 ```
 
-- `-y` runs setup non-interactively
-- `--browser` opens [dashboard.zerion.io](https://dashboard.zerion.io) so you can grab an API key and paste it back
-- skills install globally to every detected AI coding agent by default
+- authenticates in the browser via [dashboard.zerion.io](https://dashboard.zerion.io) and saves the key for you — no copy/paste
+- detects your coding agent (Claude Code, Cursor, Codex, Gemini) and installs the Zerion skills globally
+- add `-y` to skip the prompts: browser login, then every skill installed
+
+On a remote or headless host, add `--no-open` to print the authorize URL instead of opening a browser. Without a terminal (CI, piped), `init` prints API-key instructions rather than waiting on a browser login — set `ZERION_API_KEY` there instead.
 
 Or just install the CLI without setup:
 
@@ -372,8 +374,9 @@ Track wallets by name without exposing addresses in commands.
 |---------|-------------|---------|
 | `zerion login` | Authenticate — browser (dashboard) login, paste an API key, or pay-per-call | `zerion login` |
 | `zerion login --browser` | Browser auth: opens dashboard.zerion.io, captures the key via loopback | `zerion login --browser` |
-| `zerion init` | One-shot onboarding — install CLI globally, authenticate, install agent skills | `zerion init` |
-| `zerion init -y --browser` | Non-interactive init that opens dashboard.zerion.io for the API key | `npx -y zerion-cli init -y --browser` |
+| `zerion init` | One-shot onboarding — install CLI globally, browser login, install agent skills | `npx zerion-cli init` |
+| `zerion init -y` | Same, without prompts: browser login, then install every skill | `zerion init -y` |
+| `zerion init --no-open` | Print the authorize URL instead of opening a browser (remote / headless) | `zerion init --no-open` |
 | `zerion setup skills` | Install Zerion agent skills into detected coding agents | `zerion setup skills` |
 | `zerion setup skills --agent claude-code` | Install into a specific agent | `zerion setup skills --agent claude-code` |
 

--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -3,31 +3,34 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { print, printError } from "../utils/common/output.js";
-import { openBrowser } from "../utils/common/browser.js";
 import { DASHBOARD_URL } from "../utils/common/constants.js";
-import { getApiKey } from "../utils/config.js";
+import { getApiKey, setConfigValue } from "../utils/config.js";
 import { runInteractiveAuth } from "../utils/api/interactive-auth.js";
+import { authenticateWithBrowser } from "../utils/api/oauth.js";
 
 const ZERION_AGENT_REPO = "zeriontech/zerion-ai";
 
 const HELP = {
   usage: "zerion init [options]",
   description:
-    "One-shot onboarding: install the CLI globally, authenticate (browser login, paste an API key, or pay-per-call), and install Zerion agent skills into detected coding agents. By default the auth and skills steps are interactive.",
+    "One-shot onboarding: install the CLI globally, authenticate in the browser, and install Zerion agent skills into detected coding agents. Interactive by default — auth offers browser login, pasting a key, or pay-per-call, and the skills step lets you pick.",
   flags: {
-    "--yes, -y": "Non-interactive — skip prompts and install ALL skills (otherwise user picks)",
-    "--browser": "With --yes: open dashboard.zerion.io to grab an API key (interactive runs offer browser login directly)",
+    "--yes, -y": "Skip the prompts — browser login straight away, and install ALL skills (otherwise user picks)",
+    "--no-open": "Print the authorize URL instead of opening a browser (remote / headless hosts)",
     "--no-install": "Skip the global `npm install -g zerion-cli` step",
     "--no-auth": "Skip the API key configuration step",
     "--no-skills": "Skip the agent skills install step",
     "--agent <name>": "Scope skills install to one agent (e.g. claude-code, cursor)",
+    "--browser": "No-op — browser auth is the default now; accepted so older one-liners keep working",
   },
   examples: {
-    "npx -y zerion-cli init -y --browser":
-      "Bootstrap end-to-end non-interactively, opening the dashboard for the API key",
+    "npx zerion-cli init": "Bootstrap end-to-end: global install, browser login, pick skills",
+    "zerion init -y": "No prompts — browser login, then install every skill",
     "zerion init --no-install --agent claude-code":
       "Skip self-install and only set up Claude Code",
   },
+  unattended:
+    "Browser login needs someone to approve it, so without a TTY (CI, piped, container) the auth step prints API-key instructions instead of waiting on the loopback callback. Set ZERION_API_KEY or run `zerion config set apiKey <key>` there.",
 };
 
 function log(line = "") {
@@ -78,29 +81,51 @@ function ensureGlobalInstall() {
   return { ok: true, skipped: false };
 }
 
-async function ensureApiKey({ yes, browser }) {
+function printKeyFallback() {
+  log(`  → Get an API key at ${DASHBOARD_URL}, then run:`);
+  log(`      zerion config set apiKey <your-key>`);
+  log(`    (or set ZERION_API_KEY, or run 'zerion login' later)`);
+}
+
+async function ensureApiKey({ yes, open }) {
   const existing = getApiKey();
   if (existing) {
     log("  ✓ Already authenticated");
     return { ok: true, skipped: true };
   }
 
-  if (yes) {
-    log(`  ! No API key configured. Get one at ${DASHBOARD_URL} and run:`);
-    log(`    zerion config set apiKey <your-key>`);
-    log(`    (or run 'zerion login' for browser authentication)`);
-    if (browser) openBrowser(DASHBOARD_URL);
-    return { ok: true, skipped: true, reason: "non_interactive" };
-  }
-
+  // Browser login needs no prompt — approval happens out-of-band in the
+  // browser — but it does need a human to approve it, and the loopback wait is
+  // 5 minutes. A TTY is the "someone is watching" signal; without one (CI,
+  // piped, container) hand over instructions rather than hang.
   if (!process.stdin.isTTY) {
     log(`  ! No API key configured and stdin is not interactive.`);
-    log(`    Set ZERION_API_KEY or run: zerion config set apiKey <your-key>`);
+    printKeyFallback();
     return { ok: true, skipped: true, reason: "non_tty" };
   }
 
+  // --yes means "don't ask me questions", not "don't authenticate": skip the
+  // method picker and go straight to browser login, same path as
+  // `zerion login --browser`.
+  if (yes) {
+    try {
+      const { apiKey } = await authenticateWithBrowser({ open, log });
+      setConfigValue("apiKey", apiKey);
+      log("  ✓ Authenticated — API key saved to config");
+      return { ok: true, method: "oauth" };
+    } catch (err) {
+      log(`  ! Browser authorization failed: ${err.message}`);
+      return {
+        ok: false,
+        method: "oauth",
+        reason: err.code || "oauth_failed",
+        message: err.message,
+      };
+    }
+  }
+
   // Interactive: browser login (default), paste a key, or pay-per-call.
-  return runInteractiveAuth({ log, open: true });
+  return runInteractiveAuth({ log, open });
 }
 
 function installSkills({ agent, yes }) {
@@ -148,7 +173,9 @@ export default async function init(args, flags) {
   }
 
   const yes = Boolean(flags.yes || flags.y);
-  const browser = Boolean(flags.browser);
+  // parseFlags maps `--no-open` to `flags.open = false`. `--browser` is
+  // accepted but ignored — browser auth is the default now.
+  const open = flags.open !== false;
   // parseFlags maps `--no-install` to `flags.install = false`
   const skipInstall = flags.install === false;
   const skipAuth = flags.auth === false;
@@ -175,8 +202,11 @@ export default async function init(args, flags) {
   log("[2/3] Authenticate");
   const authRes = skipAuth
     ? { ok: true, skipped: true, reason: "flag" }
-    : await ensureApiKey({ yes, browser });
+    : await ensureApiKey({ yes, open });
   steps.push({ step: "auth", ...authRes });
+  // A denied or timed-out login shouldn't undo a good CLI + skills install:
+  // print the manual fallback, keep going, and still exit 0.
+  if (!authRes.ok) printKeyFallback();
 
   log("");
   log("[3/3] Install agent skills");
@@ -191,5 +221,5 @@ export default async function init(args, flags) {
 
   printSuccessSummary();
 
-  print({ ok: true, action: "init", steps });
+  print({ ok: true, action: "init", nonInteractive: yes, steps });
 }

--- a/cli/router.js
+++ b/cli/router.js
@@ -143,8 +143,9 @@ function printUsage() {
     setup: {
       "login": "Authenticate — browser (dashboard) login, paste an API key, or pay-per-call",
       "login --browser": "Browser authentication: opens dashboard.zerion.io, captures the key via loopback",
-      "init": "One-shot onboarding: install CLI globally, authenticate, install agent skills",
-      "init -y --browser": "Non-interactive init that opens dashboard.zerion.io for the API key",
+      "init": "One-shot onboarding: install CLI globally, browser login, install agent skills (`npx zerion-cli init`)",
+      "init -y": "Same without prompts: browser login, then install every skill",
+      "init --no-open": "Print the authorize URL instead of opening a browser (remote / headless hosts)",
       "setup skills": "Install Zerion agent skills via `npx skills add zeriontech/zerion-ai` (45+ hosts)",
     },
     // Trading-supported chains (swap/bridge/send). Mirrors Zerion API
@@ -164,11 +165,18 @@ function printUsage() {
 }
 
 export async function dispatch(argv) {
-  const { rest, flags } = parseFlags(argv);
+  let { rest, flags } = parseFlags(argv);
 
-  // Handle shorthand flags (-h, -v) that the flag parser treats as positional
+  // Handle shorthand flags (-h, -v, -y) that the flag parser treats as
+  // positional. `-y` matters most for `init`/`setup`, whose help advertises it:
+  // without this it was silently dropped and `init -y` still prompted. It's
+  // also filtered out of the positional args, since no command takes it as one.
   if (rest.includes("-h")) flags.help = true;
   if (rest.includes("-v")) flags.version = true;
+  if (rest.includes("-y")) {
+    flags.yes = true;
+    rest = rest.filter((arg) => arg !== "-y");
+  }
 
   if (flags.version || flags.v) {
     const { readFileSync } = await import("node:fs");

--- a/cli/tests/unit/cli/commands/init.test.mjs
+++ b/cli/tests/unit/cli/commands/init.test.mjs
@@ -68,7 +68,9 @@ describe("zerion init", () => {
     }
   });
 
-  it("auth step reports non_interactive under --yes when no key is set", () => {
+  // --yes runs a real browser login on a TTY, so the non-TTY bail-out is what
+  // keeps an unattended `init -y` from blocking on the 5-minute loopback wait.
+  it("--yes still bails out to non_tty when stdin is not interactive", () => {
     const dir = realpathSync(mkdtempSync(join(tmpdir(), "zerion-init-")));
     try {
       const res = runZerion(["init", "--no-install", "--no-skills", "--yes"], {
@@ -82,10 +84,67 @@ describe("zerion init", () => {
 
       const auth = out.steps.find((s) => s.step === "auth");
       assert.equal(auth.skipped, true);
-      assert.equal(auth.reason, "non_interactive");
+      assert.equal(auth.reason, "non_tty");
+      assert.match(res.stderr, /zerion config set apiKey/);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  // `-y` is a shorthand the flag parser can't see (it only handles `--flags`),
+  // so the router lifts it. Before that it was silently dropped, and the
+  // "non-interactive" command still showed the auth picker.
+  it("honors the -y shorthand, not just --yes", () => {
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), "zerion-init-")));
+    try {
+      const args = ["init", "--no-install", "--no-auth", "--no-skills"];
+      const withShorthand = runZerion([...args, "-y"], { env: { HOME: dir } });
+      const withoutFlag = runZerion(args, { env: { HOME: dir } });
+
+      const parse = (res) => {
+        const lines = res.stdout.trim().split("\n");
+        return JSON.parse(lines.slice(lines.findIndex((l) => l === "{")).join("\n"));
+      };
+
+      assert.equal(parse(withShorthand).nonInteractive, true);
+      assert.equal(parse(withoutFlag).nonInteractive, false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // The old onboarding one-liner (`npx -y zerion-cli init -y --browser`) must
+  // keep working verbatim — `--browser` is now implied, not removed.
+  it("accepts the legacy --browser flag as a no-op", () => {
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), "zerion-init-")));
+    try {
+      const res = runZerion(["init", "--no-install", "--no-skills", "-y", "--browser"], {
+        env: { HOME: dir, ZERION_API_KEY: "" },
+      });
+      assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+
+      const lines = res.stdout.trim().split("\n");
+      const jsonStart = lines.findIndex((line) => line === "{");
+      const out = JSON.parse(lines.slice(jsonStart).join("\n"));
+
+      const auth = out.steps.find((s) => s.step === "auth");
+      assert.equal(auth.reason, "non_tty", "same outcome as without --browser");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // `zerion init --help` is swallowed by the router's global help branch, so the
+  // usage JSON is the surface that actually documents the install command.
+  it("usage documents the short one-liner, not the old flag pile", () => {
+    const res = runZerion(["--help"]);
+    assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+
+    const usage = JSON.parse(res.stdout);
+    assert.match(usage.setup.init, /npx zerion-cli init/);
+    assert.ok(usage.setup["init -y"], "non-interactive form is documented");
+    assert.ok(usage.setup["init --no-open"], "headless escape hatch is documented");
+    assert.equal(usage.setup["init -y --browser"], undefined, "old long form is gone");
   });
 
   it("auth step reports already-authenticated when ZERION_API_KEY is set", () => {

--- a/cli/tests/unit/cli/commands/setup.test.mjs
+++ b/cli/tests/unit/cli/commands/setup.test.mjs
@@ -57,5 +57,15 @@ describe("zerion setup", () => {
       const out = JSON.parse(res.stdout);
       assert.match(out.command, /--yes/);
     });
+
+    // The flag parser only understands `--flags`, so the router has to lift the
+    // `-y` shorthand out of the positional args — otherwise it's dropped and a
+    // command documented as non-interactive still prompts. Note the ordering:
+    // `--dry-run -y` would have `-y` consumed as --dry-run's value instead.
+    it("-y shorthand is honored like --yes", () => {
+      const res = runZerion(["setup", "skills", "-y", "--dry-run"]);
+      const out = JSON.parse(res.stdout);
+      assert.match(out.command, /--yes/);
+    });
   });
 });

--- a/skills/zerion/partners/uniswap-lp.md
+++ b/skills/zerion/partners/uniswap-lp.md
@@ -17,7 +17,7 @@
 ## Requirements
 
 - Uniswap AI skills: `npx skills add Uniswap/uniswap-ai`
-- Zerion CLI: `npx -y zerion-cli init -y --browser`
+- Zerion CLI: `npx zerion-cli init`
 - Zerion API key: `export ZERION_API_KEY="zk_..."`
 
 ## Workflow

--- a/skills/zerion/partners/uniswap-x402.md
+++ b/skills/zerion/partners/uniswap-x402.md
@@ -18,7 +18,7 @@
 ## Requirements
 
 - Uniswap AI skills: `npx skills add Uniswap/uniswap-ai`
-- Zerion CLI: `npx -y zerion-cli init -y --browser`
+- Zerion CLI: `npx zerion-cli init`
 - Zerion API key: `export ZERION_API_KEY="zk_..."`
 - Uniswap API key: `export UNISWAP_API_KEY="..."`
 - `cast` (Foundry): `curl -L https://foundry.paradigm.xyz | bash && foundryup`


### PR DESCRIPTION
## Summary

The advertised onboarding one-liner was `npx -y zerion-cli init -y --browser` — five tokens with two different `-y`s, which reads like a typo. Worse, the flags actively made onboarding *worse*: `init -y` skipped real authentication in favour of "go copy a key from dashboard.zerion.io and run `zerion config set apiKey`", and `--browser` merely opened that dashboard for the copy/paste. The interactive default already did proper browser OAuth with loopback capture and auto-saved the key.

The install command is now:

```bash
npx zerion-cli init
```

## What changed

- **Docs**: `npx zerion-cli init` is the documented install command — README install section + command table, the usage JSON (`zerion --help`), `init`'s own HELP, and the two partner skills that carried the long form (`uniswap-lp`, `uniswap-x402`). The ~15 agent-facing `npm install -g zerion-cli` prerequisite lines are deliberately untouched — a non-interactive global install is the right thing for an agent to run.
- **`init -y` now authenticates for real**: runs `authenticateWithBrowser` (the same path as `zerion login --browser`, which works without a TTY because approval happens out-of-band) instead of degrading to print-and-paste. `-y` means "don't ask me questions", not "don't authenticate".
- **Unattended bail-out**: when stdin isn't a TTY (CI, piped, container) the auth step prints API-key instructions and exits 0, rather than blocking up to 5 minutes on a loopback callback nobody will complete.
- **Auth failure doesn't fail the install**: a denied / timed-out / state-mismatch login prints the manual fallback, still installs skills, and exits 0 with `steps[].auth.ok = false` in the JSON. An auth hiccup shouldn't undo a good CLI + skills install.
- **`--no-open`** added for remote/headless hosts (prints the authorize URL instead of opening a browser), mirroring `zerion login --no-open`.
- **`--browser` is accepted as a no-op**, so `npx -y zerion-cli init -y --browser` keeps working verbatim. No flag was removed.

## Drive-by bug fix

`-y` never worked. `parseFlags` only understands `--flags` (`cli/utils/common/flags.js:38`), so a bare `-y` landed in the positional args and was silently dropped — meaning the command we documented as non-interactive was *already* showing the interactive auth picker. Caught by driving `init -y` under a pty while verifying this PR. The router now lifts `-y` into `flags.yes` alongside the existing `-h`/`-v` shorthands and filters it out of positionals, and `init` reports the resolved mode as `nonInteractive` in its JSON output.

## Known issues left alone (pre-existing, out of scope)

1. **Per-command `--help` is unreachable.** `cli/router.js:187` handles `flags.help` before dispatch, so `zerion init --help` prints the global usage JSON and every command's own `HELP` object is dead code. Updated `init`'s HELP anyway so it's correct when this is fixed.
2. **Shorthands after a bare boolean flag get swallowed.** `--dry-run -y` assigns `"-y"` as `--dry-run`'s value, because `parseFlags` treats any non-`--` token as a candidate value. Affects `-h`/`-v` equally, and `-g` (documented in `zerion setup --help`) is dropped entirely for the same reason as `-y` was. Fixing this means changing the shared parser for every command, so it wants its own ticket.

## Test plan

- `npm ci && npm test` → **395/395 pass** (adds 4: the `-y` shorthand, the non-TTY `-y` bail-out, legacy `--browser` acceptance, and the usage JSON no longer advertising the long form)
- Verified `zerion init -y --no-open` under a real pty: goes straight to browser OAuth and prints the authorize URL, no picker
- Verified `zerion init` (no flags) under a pty: still shows the auth-method picker
- Verified `zerion init -y` without a TTY: prints API-key instructions, exits 0, spawns no browser

Closes WLT-2083

🤖 Generated with [Claude Code](https://claude.com/claude-code)