### PR TITLE
fix(cli): portfolio DeFi totals and Solana read paths (WLT-2076)

### DIFF
--- a/cli/commands/analytics/history.js
+++ b/cli/commands/analytics/history.js
@@ -2,15 +2,26 @@ import * as api from "../../utils/api/client.js";
 import { print, printError } from "../../utils/common/output.js";
 import { resolveAddressOrWallet } from "../../utils/wallet/resolve.js";
 import { formatHistory } from "../../utils/common/format.js";
+import { resolveReadChainAsync } from "../../utils/common/validate.js";
 import { resolveAuth } from "../../utils/api/auth.js";
 
 export default async function history(args, flags) {
+  // Validate against the live catalog so a typo reports `unsupported_chain`
+  // with a `zerion chains` hint rather than a raw 400 from the API.
+  const chainCheck = await resolveReadChainAsync(flags.chain);
+  if (chainCheck.error) {
+    printError(chainCheck.error.code, chainCheck.error.message, {
+      suggestion: chainCheck.error.suggestion,
+    });
+    process.exit(1);
+  }
+
   const { walletName, address } = await resolveAddressOrWallet(args, flags);
 
   try {
     const auth = resolveAuth(flags);
     const response = await api.getTransactions(address, {
-      chainId: flags.chain,
+      chainId: chainCheck.chainId,
       limit: flags.limit ? parseInt(flags.limit, 10) : 10,
       auth,
     });

--- a/cli/commands/analytics/overview.js
+++ b/cli/commands/analytics/overview.js
@@ -8,7 +8,11 @@ import { summarizeAnalyze } from "../../utils/common/analyze.js";
 import { print, printError } from "../../utils/common/output.js";
 import { resolveAuth } from "../../utils/api/auth.js";
 import { resolveAddressOrWallet } from "../../utils/wallet/resolve.js";
-import { resolveReadChainAsync, resolvePositionFilterForAddress } from "../../utils/common/validate.js";
+import {
+  resolveReadChainAsync,
+  resolvePositionFilterForAddress,
+  resolvePositionsFlag,
+} from "../../utils/common/validate.js";
 
 export default async function walletAnalyze(args, flags) {
   // Validate against the live catalog (not the static 14-chain registry) so any
@@ -22,6 +26,16 @@ export default async function walletAnalyze(args, flags) {
   }
   const chainId = chainCheck.chainId;
 
+  // `--defi` is a synonym for `--positions defi` here too. `analyze` used to
+  // read only `flags.positions`, so `--defi` was silently ignored — including
+  // on Solana, where it must refuse rather than return token holdings.
+  const positionsFlag = resolvePositionsFlag(flags);
+  if (positionsFlag.error) {
+    const { code, message, ...details } = positionsFlag.error;
+    printError(code, message, details);
+    process.exit(1);
+  }
+
   const { walletName, address: resolved } = await resolveAddressOrWallet(args, flags);
   const addr = encodeURIComponent(resolved);
   const txLimit = flags.limit ? parseInt(flags.limit, 10) : 10;
@@ -30,7 +44,7 @@ export default async function walletAnalyze(args, flags) {
   // endpoint accepts for base58 addresses. Without this the positions leg 400s
   // and `analyze` reports `count: 0` with a `failures` entry — which reads like
   // an empty wallet rather than a filter the API refused.
-  const filterCheck = resolvePositionFilterForAddress(resolved, flags.positions);
+  const filterCheck = resolvePositionFilterForAddress(resolved, positionsFlag.value);
   if (filterCheck.error) {
     printError(filterCheck.error.code, filterCheck.error.message, {
       suggestion: filterCheck.error.suggestion,
@@ -64,7 +78,10 @@ export default async function walletAnalyze(args, flags) {
       .map((r, i) => (r.status === "rejected" ? labels[i] : null))
       .filter(Boolean);
 
-    const summary = summarizeAnalyze(resolved, ...values);
+    // Pass --chain through: the positions and transactions legs are filtered by
+    // it, so the total has to be that chain's slice or the summary reports a
+    // wallet-wide number over a one-chain list (same fix as `portfolio`).
+    const summary = summarizeAnalyze(resolved, ...values, { chainId });
     if (walletName !== resolved) summary.label = walletName;
     if (failures.length) summary.failures = failures;
     if (filterCheck.note) summary.notes = [filterCheck.note];

--- a/cli/commands/analytics/overview.js
+++ b/cli/commands/analytics/overview.js
@@ -62,11 +62,12 @@ export default async function walletAnalyze(args, flags) {
   try {
     const auth = resolveAuth(flags);
     const results = await Promise.allSettled([
-      // Go through getPortfolio so the total carries the same
-      // `filter[positions]` default as everything else — fetching this endpoint
-      // raw is what let the summary pair an only_simple total with a
-      // no_filter position list.
-      getPortfolio(resolved, { auth }),
+      // The total must carry the same `filter[positions]` as the position
+      // list — pairing them differently is the bug this PR fixes, and it cuts
+      // both ways: a raw fetch paired an only_simple total with a no_filter
+      // list, and a hardcoded no_filter would pair an all-position total with
+      // an explicit `--positions simple` list.
+      getPortfolio(resolved, { auth, positionFilter: filterCheck.filter }),
       fetchAPI(`/wallets/${addr}/positions/`, posParams, auth),
       fetchAPI(`/wallets/${addr}/transactions/`, txParams, auth),
       fetchAPI(`/wallets/${addr}/pnl`, {}, auth),

--- a/cli/commands/analytics/overview.js
+++ b/cli/commands/analytics/overview.js
@@ -3,12 +3,12 @@
  * Returns a concise summary (portfolio, top positions, recent txs, PnL).
  */
 
-import { fetchAPI } from "../../utils/api/client.js";
+import { fetchAPI, getPortfolio } from "../../utils/api/client.js";
 import { summarizeAnalyze } from "../../utils/common/analyze.js";
 import { print, printError } from "../../utils/common/output.js";
 import { resolveAuth } from "../../utils/api/auth.js";
 import { resolveAddressOrWallet } from "../../utils/wallet/resolve.js";
-import { resolveReadChainAsync } from "../../utils/common/validate.js";
+import { resolveReadChainAsync, resolvePositionFilterForAddress } from "../../utils/common/validate.js";
 
 export default async function walletAnalyze(args, flags) {
   // Validate against the live catalog (not the static 14-chain registry) so any
@@ -26,19 +26,33 @@ export default async function walletAnalyze(args, flags) {
   const addr = encodeURIComponent(resolved);
   const txLimit = flags.limit ? parseInt(flags.limit, 10) : 10;
 
-  const posParams = { "filter[positions]": "no_filter" };
+  // Same Solana rule as `positions`: `only_simple` is the only filter that
+  // endpoint accepts for base58 addresses. Without this the positions leg 400s
+  // and `analyze` reports `count: 0` with a `failures` entry — which reads like
+  // an empty wallet rather than a filter the API refused.
+  const filterCheck = resolvePositionFilterForAddress(resolved, flags.positions);
+  if (filterCheck.error) {
+    printError(filterCheck.error.code, filterCheck.error.message, {
+      suggestion: filterCheck.error.suggestion,
+    });
+    process.exit(1);
+  }
+
+  const posParams = { "filter[positions]": filterCheck.filter };
   const txParams = { "page[size]": txLimit };
   if (chainId) {
     posParams["filter[chain_ids]"] = chainId;
     txParams["filter[chain_ids]"] = chainId;
   }
-  if (flags.positions === "simple") posParams["filter[positions]"] = "only_simple";
-  else if (flags.positions === "defi") posParams["filter[positions]"] = "only_complex";
 
   try {
     const auth = resolveAuth(flags);
     const results = await Promise.allSettled([
-      fetchAPI(`/wallets/${addr}/portfolio`, {}, auth),
+      // Go through getPortfolio so the total carries the same
+      // `filter[positions]` default as everything else — fetching this endpoint
+      // raw is what let the summary pair an only_simple total with a
+      // no_filter position list.
+      getPortfolio(resolved, { auth }),
       fetchAPI(`/wallets/${addr}/positions/`, posParams, auth),
       fetchAPI(`/wallets/${addr}/transactions/`, txParams, auth),
       fetchAPI(`/wallets/${addr}/pnl`, {}, auth),
@@ -53,6 +67,7 @@ export default async function walletAnalyze(args, flags) {
     const summary = summarizeAnalyze(resolved, ...values);
     if (walletName !== resolved) summary.label = walletName;
     if (failures.length) summary.failures = failures;
+    if (filterCheck.note) summary.notes = [filterCheck.note];
     if (auth.kind !== "apiKey") summary.auth = auth.kind;
 
     print(summary);

--- a/cli/commands/analytics/portfolio.js
+++ b/cli/commands/analytics/portfolio.js
@@ -2,25 +2,48 @@ import * as api from "../../utils/api/client.js";
 import { print, printError } from "../../utils/common/output.js";
 import { resolveAddressOrWallet } from "../../utils/wallet/resolve.js";
 import { formatPortfolio } from "../../utils/common/format.js";
+import { resolveReadChainAsync, resolvePositionFilterForAddress } from "../../utils/common/validate.js";
 import { resolveAuth } from "../../utils/api/auth.js";
 
 export default async function portfolio(args, flags) {
+  // Validate against the live catalog (not the static 14-chain registry) so any
+  // chain Zerion indexes can be filtered on, and a typo reports
+  // `unsupported_chain` rather than a raw 400 from the API.
+  const chainCheck = await resolveReadChainAsync(flags.chain);
+  if (chainCheck.error) {
+    printError(chainCheck.error.code, chainCheck.error.message, {
+      suggestion: chainCheck.error.suggestion,
+    });
+    process.exit(1);
+  }
+  const chainId = chainCheck.chainId;
+
   const { walletName, address } = await resolveAddressOrWallet(args, flags);
+
+  // `portfolio` has no --positions flag: it always wants the whole wallet.
+  // On Solana that resolves to `only_simple`, the only filter the positions
+  // endpoint accepts there.
+  const filterCheck = resolvePositionFilterForAddress(address, undefined);
 
   try {
     const auth = resolveAuth(flags);
     const [portfolioRes, positionsRes] = await Promise.all([
       api.getPortfolio(address, { auth }),
       api.getPositions(address, {
-        chainId: flags.chain,
-        positionFilter: "only_simple",
+        chainId,
+        positionFilter: filterCheck.filter,
         auth,
       }),
     ]);
 
-    const total = portfolioRes.data?.attributes?.total?.positions ?? 0;
-    const change24h =
-      portfolioRes.data?.attributes?.changes?.absolute_1d ?? null;
+    const attrs = portfolioRes.data?.attributes ?? {};
+    const byChain = attrs.positions_distribution_by_chain ?? {};
+    // The portfolio endpoint takes no chain filter, so when --chain narrows the
+    // position list we take that chain's slice of the distribution too —
+    // otherwise the header reports an all-chain total over a one-chain list.
+    const total = chainId ? (byChain[chainId] ?? 0) : (attrs.total?.positions ?? 0);
+    // 24h change is only published wallet-wide; don't attribute it to one chain.
+    const change24h = chainId ? null : (attrs.changes?.absolute_1d ?? null);
 
     const positions = (positionsRes.data || [])
       .map((p) => ({
@@ -44,6 +67,8 @@ export default async function portfolio(args, flags) {
       positions: positions.slice(0, flags.limit ? parseInt(flags.limit, 10) : 20),
       positionCount: positions.length,
     };
+    if (chainId) data.chain = chainId;
+    if (filterCheck.note) data.notes = [filterCheck.note];
     print(data, formatPortfolio);
   } catch (err) {
     printError(err.code || "portfolio_error", err.message);

--- a/cli/commands/analytics/portfolio.js
+++ b/cli/commands/analytics/portfolio.js
@@ -3,6 +3,7 @@ import { print, printError } from "../../utils/common/output.js";
 import { resolveAddressOrWallet } from "../../utils/wallet/resolve.js";
 import { formatPortfolio } from "../../utils/common/format.js";
 import { resolveReadChainAsync, resolvePositionFilterForAddress } from "../../utils/common/validate.js";
+import { portfolioTotals } from "../../utils/common/portfolio.js";
 import { resolveAuth } from "../../utils/api/auth.js";
 
 export default async function portfolio(args, flags) {
@@ -36,14 +37,9 @@ export default async function portfolio(args, flags) {
       }),
     ]);
 
-    const attrs = portfolioRes.data?.attributes ?? {};
-    const byChain = attrs.positions_distribution_by_chain ?? {};
-    // The portfolio endpoint takes no chain filter, so when --chain narrows the
-    // position list we take that chain's slice of the distribution too —
-    // otherwise the header reports an all-chain total over a one-chain list.
-    const total = chainId ? (byChain[chainId] ?? 0) : (attrs.total?.positions ?? 0);
-    // 24h change is only published wallet-wide; don't attribute it to one chain.
-    const change24h = chainId ? null : (attrs.changes?.absolute_1d ?? null);
+    const totals = portfolioTotals(portfolioRes.data?.attributes, chainId);
+    const total = totals.total ?? 0;
+    const change24h = totals.change24h;
 
     const positions = (positionsRes.data || [])
       .map((p) => ({
@@ -53,6 +49,11 @@ export default async function portfolio(args, flags) {
         quantity: p.attributes.quantity?.float,
         value: p.attributes.value,
         price: p.attributes.price,
+        // The total now includes DeFi, so the list does too. Without these an
+        // 8 ETH wallet row and a 4 ETH staked row render identically and read
+        // like a double count.
+        position_type: p.attributes.position_type ?? null,
+        protocol: p.attributes.application_metadata?.name ?? p.attributes.protocol ?? null,
       }))
       .filter((p) => p.value > 0)
       .sort((a, b) => b.value - a.value);

--- a/cli/commands/analytics/portfolio.js
+++ b/cli/commands/analytics/portfolio.js
@@ -37,9 +37,10 @@ export default async function portfolio(args, flags) {
       }),
     ]);
 
-    const totals = portfolioTotals(portfolioRes.data?.attributes, chainId);
-    const total = totals.total ?? 0;
-    const change24h = totals.change24h;
+    // No `?? 0`: portfolioTotals keeps "the API said nothing" as null, and
+    // `analyze` reports the same null — coercing here made the two commands
+    // disagree ($0.00 vs null) on a chain the wallet holds nothing on.
+    const { total, change24h } = portfolioTotals(portfolioRes.data?.attributes, chainId);
 
     const positions = (positionsRes.data || [])
       .map((p) => ({

--- a/cli/commands/analytics/positions.js
+++ b/cli/commands/analytics/positions.js
@@ -11,7 +11,7 @@
 import * as api from "../../utils/api/client.js";
 import { print, printError } from "../../utils/common/output.js";
 import { resolveAddressOrWallet } from "../../utils/wallet/resolve.js";
-import { resolveReadChainAsync, validatePositions, resolvePositionFilterForAddress } from "../../utils/common/validate.js";
+import { resolveReadChainAsync, resolvePositionsFlag, resolvePositionFilterForAddress } from "../../utils/common/validate.js";
 import { resolveAuth } from "../../utils/api/auth.js";
 import { formatPositions, formatDefiPositions } from "../../utils/common/format.js";
 
@@ -27,30 +27,22 @@ export default async function walletPositions(args, flags) {
   }
   const chainId = chainCheck.chainId;
 
-  // --defi is shorthand for --positions defi + DeFi-grouped output.
-  // Conflict only if user also passed an incompatible --positions value.
-  const defiMode = !!flags.defi;
-  if (defiMode && flags.positions && flags.positions !== "defi") {
-    printError(
-      "conflicting_flags",
-      `--defi cannot be combined with --positions ${flags.positions}. Use one or the other.`,
-    );
+  // --defi is shorthand for --positions defi + DeFi-grouped output. The flag
+  // normalisation is shared with `analyze`, which accepts the same two flags.
+  const positionsFlag = resolvePositionsFlag(flags);
+  if (positionsFlag.error) {
+    const { code, message, ...details } = positionsFlag.error;
+    printError(code, message, details);
     process.exit(1);
   }
-  if (defiMode) flags.positions = "defi";
-
-  const posErr = validatePositions(flags.positions);
-  if (posErr) {
-    printError(posErr.code, posErr.message, { supportedValues: posErr.supportedValues });
-    process.exit(1);
-  }
+  const { value: positionsValue, defiMode } = positionsFlag;
 
   const { walletName, address } = await resolveAddressOrWallet(args, flags);
 
   // Solana takes only `only_simple` on this endpoint — downgrade an implicit
   // "everything", but refuse an explicit DeFi ask rather than quietly handing
   // back token holdings that were never what was requested.
-  const filterCheck = resolvePositionFilterForAddress(address, flags.positions);
+  const filterCheck = resolvePositionFilterForAddress(address, positionsValue);
   if (filterCheck.error) {
     printError(filterCheck.error.code, filterCheck.error.message, {
       suggestion: filterCheck.error.suggestion,
@@ -104,7 +96,7 @@ export default async function walletPositions(args, flags) {
       wallet: { name: walletName, address },
       positions,
       count: positions.length,
-      filter: flags.positions || "all",
+      filter: positionsValue || "all",
     };
     if (filterCheck.note) payload.notes = [filterCheck.note];
     print(payload, formatPositions);

--- a/cli/commands/analytics/positions.js
+++ b/cli/commands/analytics/positions.js
@@ -11,7 +11,7 @@
 import * as api from "../../utils/api/client.js";
 import { print, printError } from "../../utils/common/output.js";
 import { resolveAddressOrWallet } from "../../utils/wallet/resolve.js";
-import { resolveReadChainAsync, validatePositions, resolvePositionFilter } from "../../utils/common/validate.js";
+import { resolveReadChainAsync, validatePositions, resolvePositionFilterForAddress } from "../../utils/common/validate.js";
 import { resolveAuth } from "../../utils/api/auth.js";
 import { formatPositions, formatDefiPositions } from "../../utils/common/format.js";
 
@@ -47,11 +47,22 @@ export default async function walletPositions(args, flags) {
 
   const { walletName, address } = await resolveAddressOrWallet(args, flags);
 
+  // Solana takes only `only_simple` on this endpoint — downgrade an implicit
+  // "everything", but refuse an explicit DeFi ask rather than quietly handing
+  // back token holdings that were never what was requested.
+  const filterCheck = resolvePositionFilterForAddress(address, flags.positions);
+  if (filterCheck.error) {
+    printError(filterCheck.error.code, filterCheck.error.message, {
+      suggestion: filterCheck.error.suggestion,
+    });
+    process.exit(1);
+  }
+
   try {
     const auth = resolveAuth(flags);
     const response = await api.getPositions(address, {
       chainId,
-      positionFilter: resolvePositionFilter(flags.positions),
+      positionFilter: filterCheck.filter,
       auth,
     });
 
@@ -89,12 +100,14 @@ export default async function walletPositions(args, flags) {
       .filter((p) => p.value > 0)
       .sort((a, b) => b.value - a.value);
 
-    print({
+    const payload = {
       wallet: { name: walletName, address },
       positions,
       count: positions.length,
       filter: flags.positions || "all",
-    }, formatPositions);
+    };
+    if (filterCheck.note) payload.notes = [filterCheck.note];
+    print(payload, formatPositions);
   } catch (err) {
     printError(err.code || "positions_error", err.message);
     process.exit(1);

--- a/cli/tests/unit/cli/utils/api/client.test.mjs
+++ b/cli/tests/unit/cli/utils/api/client.test.mjs
@@ -3,7 +3,7 @@
 
 import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, it } from "node:test";
-import { fetchAPI } from "#zerion/utils/api/client.js";
+import { fetchAPI, getPortfolio, getPositions } from "#zerion/utils/api/client.js";
 
 const originalFetch = globalThis.fetch;
 const originalApiKey = process.env.ZERION_API_KEY;
@@ -69,5 +69,61 @@ describe("fetchAPI — User-Agent header", () => {
       capturedHeaders["User-Agent"]?.startsWith("zerion-cli"),
       "User-Agent must reach the underlying fetch even when wrappers are in play"
     );
+  });
+});
+
+// The portfolio endpoint defaults `filter[positions]` to `only_simple`
+// server-side, which drops every DeFi position from the total and made the CLI
+// disagree with the Zerion app on any wallet holding DeFi (WLT-2076). The
+// default must be explicit and must survive on the wire.
+describe("getPortfolio — position filter", () => {
+  function captureUrl() {
+    const seen = {};
+    globalThis.fetch = async (url) => {
+      seen.url = new URL(url);
+      return new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    return seen;
+  }
+
+  it("asks for no_filter by default so DeFi is in the total", async () => {
+    const seen = captureUrl();
+    await getPortfolio("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+    assert.equal(seen.url.searchParams.get("filter[positions]"), "no_filter");
+    assert.equal(seen.url.searchParams.get("currency"), "usd");
+  });
+
+  it("honours an explicit filter override", async () => {
+    const seen = captureUrl();
+    await getPortfolio("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", {
+      positionFilter: "only_simple",
+    });
+    assert.equal(seen.url.searchParams.get("filter[positions]"), "only_simple");
+  });
+});
+
+describe("getPositions — position filter", () => {
+  it("defaults to no_filter and forwards an explicit filter", async () => {
+    let seen;
+    globalThis.fetch = async (url) => {
+      seen = new URL(url);
+      return new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    await getPositions("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+    assert.equal(seen.searchParams.get("filter[positions]"), "no_filter");
+
+    // Solana callers pass only_simple explicitly — the client itself stays
+    // dumb, the decision lives in resolvePositionFilterForAddress.
+    await getPositions("ebDDhKWSBXPirnzXgFWTTArfymyG4n5fpg1Y5UgwNRY", {
+      positionFilter: "only_simple",
+    });
+    assert.equal(seen.searchParams.get("filter[positions]"), "only_simple");
   });
 });

--- a/cli/tests/unit/cli/utils/chain/address.test.mjs
+++ b/cli/tests/unit/cli/utils/chain/address.test.mjs
@@ -1,0 +1,49 @@
+// Address shape helpers. These decide which ecosystem a raw address belongs to,
+// which in turn picks the `filter[positions]` value and the read/sign guard —
+// so the boundaries (length, base58 alphabet) matter more than the happy path.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isEvmAddress, isSolanaAddress } from "#zerion/utils/chain/address.js";
+
+describe("isEvmAddress", () => {
+  it("accepts a 0x address in either case", () => {
+    assert.ok(isEvmAddress("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"));
+    assert.ok(isEvmAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045"));
+  });
+
+  it("rejects wrong length, missing prefix, and non-hex", () => {
+    assert.ok(!isEvmAddress("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA960"));
+    assert.ok(!isEvmAddress("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"));
+    assert.ok(!isEvmAddress("0xZZdA6BF26964aF9D7eEd9e03E53415D37aA96045"));
+  });
+
+  it("rejects non-strings", () => {
+    assert.ok(!isEvmAddress(undefined));
+    assert.ok(!isEvmAddress(null));
+  });
+});
+
+describe("isSolanaAddress", () => {
+  it("accepts 43- and 44-char base58 pubkeys", () => {
+    assert.ok(isSolanaAddress("ebDDhKWSBXPirnzXgFWTTArfymyG4n5fpg1Y5UgwNRY"));
+    assert.ok(isSolanaAddress("8xLdoxKr3J5dQX2dQuzC7v3sqXq6ZwVz1aVzaB6gqW9F"));
+  });
+
+  it("rejects base58-ambiguous characters (0, O, I, l)", () => {
+    assert.ok(!isSolanaAddress("0bDDhKWSBXPirnzXgFWTTArfymyG4n5fpg1Y5UgwNRY"));
+    assert.ok(!isSolanaAddress("ObDDhKWSBXPirnzXgFWTTArfymyG4n5fpg1Y5UgwNRY"));
+    assert.ok(!isSolanaAddress("IbDDhKWSBXPirnzXgFWTTArfymyG4n5fpg1Y5UgwNRY"));
+    assert.ok(!isSolanaAddress("lbDDhKWSBXPirnzXgFWTTArfymyG4n5fpg1Y5UgwNRY"));
+  });
+
+  it("rejects lengths outside 43–44", () => {
+    assert.ok(!isSolanaAddress("ebDDhKWSBXPirnzXgFWTTArfymyG4n5fpg1Y5Ugw"));
+    assert.ok(!isSolanaAddress("ebDDhKWSBXPirnzXgFWTTArfymyG4n5fpg1Y5UgwNRYxx"));
+  });
+
+  it("does not classify an EVM address or a short wallet name as Solana", () => {
+    assert.ok(!isSolanaAddress("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"));
+    assert.ok(!isSolanaAddress("zerts-sol"));
+  });
+});

--- a/cli/tests/unit/cli/utils/common/analyze.test.mjs
+++ b/cli/tests/unit/cli/utils/common/analyze.test.mjs
@@ -55,3 +55,43 @@ describe("summarizeAnalyze", () => {
     assert.equal(result.wallet.query, "vitalik.eth");
   });
 });
+
+// `analyze --chain X` filters the positions and transactions legs, but the
+// /portfolio endpoint takes no chain filter — so the total has to be sliced the
+// same way `portfolio` slices it, or the summary reports a wallet-wide number
+// over a one-chain list (WLT-2076).
+describe("summarizeAnalyze — --chain scoping", () => {
+  const portfolio = { data: { attributes: {
+    total: { positions: 50000 },
+    changes: { absolute_1d: -100, percent_1d: -0.2 },
+    positions_distribution_by_chain: { ethereum: 45000, base: 5000 },
+  } } };
+
+  it("reports the chain's slice as the total", () => {
+    const result = summarizeAnalyze("0xABC", portfolio, null, null, null, { chainId: "base" });
+    assert.equal(result.portfolio.total, 5000);
+    assert.equal(result.portfolio.chain, "base");
+  });
+
+  it("drops the 24h change when scoped to a chain", () => {
+    const result = summarizeAnalyze("0xABC", portfolio, null, null, null, { chainId: "base" });
+    assert.equal(result.portfolio.change_1d, null);
+  });
+
+  it("keeps the full chain distribution so the rest is still visible", () => {
+    const result = summarizeAnalyze("0xABC", portfolio, null, null, null, { chainId: "base" });
+    assert.deepEqual(result.portfolio.chains, { ethereum: 45000, base: 5000 });
+  });
+
+  it("is unchanged with no chain: wallet-wide total, change present, no chain key", () => {
+    const result = summarizeAnalyze("0xABC", portfolio, null, null, null);
+    assert.equal(result.portfolio.total, 50000);
+    assert.deepEqual(result.portfolio.change_1d, { absolute_1d: -100, percent_1d: -0.2 });
+    assert.equal("chain" in result.portfolio, false);
+  });
+
+  it("reports null, not the wallet total, for a chain the wallet is absent from", () => {
+    const result = summarizeAnalyze("0xABC", portfolio, null, null, null, { chainId: "arbitrum" });
+    assert.equal(result.portfolio.total, null);
+  });
+});

--- a/cli/tests/unit/cli/utils/common/format-notes.test.mjs
+++ b/cli/tests/unit/cli/utils/common/format-notes.test.mjs
@@ -1,0 +1,116 @@
+// Pretty-mode rendering of the two things WLT-2076 added to the JSON payloads:
+// `notes` (why a Solana result looks thinner than asked for) and DeFi rows in
+// `portfolio` (which the total now includes).
+//
+// Assertions strip ANSI so they don't encode the colour scheme.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { formatPortfolio, formatPositions } from "#zerion/utils/common/format.js";
+
+const strip = (s) => s.replace(/\[[0-9;]*m/g, "");
+
+const WALLET = { name: "sol-ro", address: "5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9" };
+const NOTE = "Solana has no DeFi positions in the Zerion API yet — showing token holdings only.";
+
+describe("formatPortfolio — notes", () => {
+  const base = {
+    wallet: WALLET,
+    portfolio: { total: 1000, change_24h: null, currency: "usd" },
+    positions: [{ symbol: "SOL", chain: "solana", value: 1000, quantity: 5 }],
+    positionCount: 1,
+  };
+
+  it("prints the note in pretty mode", () => {
+    const out = strip(formatPortfolio({ ...base, notes: [NOTE] }));
+    assert.match(out, /token holdings only/);
+  });
+
+  it("prints nothing extra when there are no notes", () => {
+    const out = strip(formatPortfolio(base));
+    assert.doesNotMatch(out, /ⓘ/);
+  });
+
+  it("shows the chain when the total is a chain slice", () => {
+    const out = strip(formatPortfolio({ ...base, chain: "base" }));
+    assert.match(out.split("\n")[0], /base/);
+  });
+});
+
+describe("formatPortfolio — DeFi rows", () => {
+  // 8 ETH held + 4 ETH staked: two rows, same symbol, same chain. Without a
+  // type column this reads as a double count.
+  const data = {
+    wallet: { name: "evm", address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },
+    portfolio: { total: 12000, change_24h: 10, currency: "usd" },
+    positions: [
+      { symbol: "ETH", chain: "ethereum", value: 8000, quantity: 8, position_type: "wallet", protocol: null },
+      { symbol: "ETH", chain: "ethereum", value: 4000, quantity: 4, position_type: "staked", protocol: "Lido" },
+    ],
+    positionCount: 2,
+  };
+
+  it("labels the protocol row with its type and dapp", () => {
+    const rows = strip(formatPortfolio(data)).split("\n").filter((l) => l.includes("ETH"));
+    const staked = rows.find((l) => l.includes("4.0000"));
+    assert.match(staked, /staked/);
+    assert.match(staked, /Lido/);
+  });
+
+  it("leaves the plain wallet row unlabelled", () => {
+    const rows = strip(formatPortfolio(data)).split("\n").filter((l) => l.includes("ETH"));
+    const held = rows.find((l) => l.includes("8.0000"));
+    assert.doesNotMatch(held, /staked|Lido/);
+  });
+
+  it("adds no Type column when every row is a plain holding", () => {
+    const simple = { ...data, positions: [data.positions[0]] };
+    assert.doesNotMatch(strip(formatPortfolio(simple)), /Type/);
+  });
+});
+
+describe("formatPositions — notes", () => {
+  const base = {
+    wallet: WALLET,
+    positions: [{ symbol: "SOL", chain: "solana", value: 1000, quantity: 5 }],
+    count: 1,
+    filter: "all",
+  };
+
+  it("prints the note above the table", () => {
+    const lines = strip(formatPositions({ ...base, notes: [NOTE] })).split("\n");
+    const noteAt = lines.findIndex((l) => l.includes("token holdings only"));
+    const headerAt = lines.findIndex((l) => l.includes("Token"));
+    assert.ok(noteAt > -1, "note not rendered");
+    assert.ok(noteAt < headerAt, "note rendered below the table header");
+  });
+
+  it("renders unchanged without notes", () => {
+    assert.doesNotMatch(strip(formatPositions(base)), /ⓘ/);
+  });
+});
+
+// `portfolio.change_24h` carries `changes.absolute_1d` — dollars. It used to be
+// printed through the percent formatter, so a -$4,048 day read as "-4048.26%".
+describe("formatPortfolio — 24h change units", () => {
+  const withChange = (change_24h) => ({
+    wallet: { name: "w", address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },
+    portfolio: { total: 27_369_610.3, change_24h, currency: "usd" },
+    positions: [],
+    positionCount: 0,
+  });
+
+  it("renders a negative change as dollars, not a percentage", () => {
+    const out = strip(formatPortfolio(withChange(-4048.26)));
+    assert.match(out, /24h: -\$4,048\.26/);
+    assert.doesNotMatch(out, /%/);
+  });
+
+  it("signs a positive change", () => {
+    assert.match(strip(formatPortfolio(withChange(4370.9))), /24h: \+\$4,370\.90/);
+  });
+
+  it("renders a missing change as a dash", () => {
+    assert.match(strip(formatPortfolio(withChange(null))), /24h: -\n?/);
+  });
+});

--- a/cli/tests/unit/cli/utils/common/portfolio.test.mjs
+++ b/cli/tests/unit/cli/utils/common/portfolio.test.mjs
@@ -1,0 +1,42 @@
+// The `/portfolio` endpoint takes no chain filter, so `--chain` has to be
+// applied to the total by hand. Getting this wrong reports a wallet-wide number
+// above a one-chain position list (WLT-2076).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { portfolioTotals } from "#zerion/utils/common/portfolio.js";
+
+const ATTRS = {
+  total: { positions: 1_116_026 },
+  changes: { absolute_1d: 1746, percent_1d: 0.15 },
+  positions_distribution_by_chain: { ethereum: 1_098_324, base: 17_702, zero: 0 },
+};
+
+describe("portfolioTotals", () => {
+  it("reports the wallet-wide total and 24h change with no chain", () => {
+    assert.deepEqual(portfolioTotals(ATTRS, null), { total: 1_116_026, change24h: 1746 });
+  });
+
+  it("reports the chain's slice and drops the 24h change", () => {
+    // The API publishes changes wallet-wide only — attributing 1746 to base
+    // would be an invented number.
+    assert.deepEqual(portfolioTotals(ATTRS, "base"), { total: 17_702, change24h: null });
+  });
+
+  it("keeps a genuine zero slice distinct from a missing one", () => {
+    assert.equal(portfolioTotals(ATTRS, "zero").total, 0);
+    assert.equal(portfolioTotals(ATTRS, "arbitrum").total, null);
+  });
+
+  it("returns null rather than inventing 0 when the API said nothing", () => {
+    assert.deepEqual(portfolioTotals({}, null), { total: null, change24h: null });
+    assert.deepEqual(portfolioTotals(undefined, null), { total: null, change24h: null });
+    assert.equal(portfolioTotals(undefined, "base").total, null);
+  });
+
+  it("never pairs a chain-scoped total with a wallet-wide change", () => {
+    for (const chain of ["ethereum", "base", "zero", "unknown-chain"]) {
+      assert.equal(portfolioTotals(ATTRS, chain).change24h, null, `chain '${chain}'`);
+    }
+  });
+});

--- a/cli/tests/unit/cli/utils/common/validate.test.mjs
+++ b/cli/tests/unit/cli/utils/common/validate.test.mjs
@@ -3,6 +3,7 @@ import { describe, it, after, beforeEach } from "node:test";
 import {
   validatePositions,
   resolvePositionFilter,
+  resolvePositionFilterForAddress,
   resolveSigningChainAsync,
   resolveReadChainAsync,
   POSITION_FILTERS,
@@ -164,6 +165,50 @@ describe("resolveReadChainAsync", () => {
       const result = await resolveReadChainAsync(value);
       assert.equal(result.error, undefined);
       assert.equal(result.chainId, null);
+    }
+  });
+});
+
+// The Zerion API has no protocol positions for Solana yet: `/positions/` 400s
+// on both `no_filter` and `only_complex` for base58 addresses. This helper is
+// the single place that decides what to send (WLT-2076).
+describe("resolvePositionFilterForAddress", () => {
+  const EVM = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+  const SOL = "ebDDhKWSBXPirnzXgFWTTArfymyG4n5fpg1Y5UgwNRY";
+
+  it("leaves every filter untouched for EVM addresses", () => {
+    assert.deepEqual(resolvePositionFilterForAddress(EVM, undefined), { filter: "no_filter" });
+    assert.deepEqual(resolvePositionFilterForAddress(EVM, "all"), { filter: "no_filter" });
+    assert.deepEqual(resolvePositionFilterForAddress(EVM, "simple"), { filter: "only_simple" });
+    assert.deepEqual(resolvePositionFilterForAddress(EVM, "defi"), { filter: "only_complex" });
+  });
+
+  it("downgrades an implicit 'everything' to only_simple on Solana, with a note", () => {
+    const result = resolvePositionFilterForAddress(SOL, undefined);
+    assert.equal(result.filter, "only_simple");
+    assert.match(result.note, /Solana/);
+    assert.equal(result.error, undefined);
+  });
+
+  it("downgrades an explicit --positions all the same way", () => {
+    assert.equal(resolvePositionFilterForAddress(SOL, "all").filter, "only_simple");
+  });
+
+  it("passes --positions simple through without a note", () => {
+    assert.deepEqual(resolvePositionFilterForAddress(SOL, "simple"), { filter: "only_simple" });
+  });
+
+  it("refuses an explicit DeFi ask on Solana rather than silently substituting", () => {
+    const result = resolvePositionFilterForAddress(SOL, "defi");
+    assert.equal(result.filter, undefined);
+    assert.equal(result.error.code, "solana_defi_unsupported");
+    assert.match(result.error.suggestion, /EVM address/);
+  });
+
+  it("never returns a filter the Solana endpoint rejects", () => {
+    for (const flag of [undefined, "all", "simple", "defi"]) {
+      const { filter } = resolvePositionFilterForAddress(SOL, flag);
+      if (filter) assert.equal(filter, "only_simple", `flag '${flag}' produced '${filter}'`);
     }
   });
 });

--- a/cli/tests/unit/cli/utils/common/validate.test.mjs
+++ b/cli/tests/unit/cli/utils/common/validate.test.mjs
@@ -4,6 +4,7 @@ import {
   validatePositions,
   resolvePositionFilter,
   resolvePositionFilterForAddress,
+  resolvePositionsFlag,
   resolveSigningChainAsync,
   resolveReadChainAsync,
   POSITION_FILTERS,
@@ -210,5 +211,44 @@ describe("resolvePositionFilterForAddress", () => {
       const { filter } = resolvePositionFilterForAddress(SOL, flag);
       if (filter) assert.equal(filter, "only_simple", `flag '${flag}' produced '${filter}'`);
     }
+  });
+});
+
+// `--defi` and `--positions defi` mean the same thing, and both `positions` and
+// `analyze` accept them. The shorthand used to live inside `positions` only, so
+// `analyze --defi` was dropped silently — including on Solana, where it has to
+// refuse rather than hand back token holdings.
+describe("resolvePositionsFlag", () => {
+  it("returns nothing asked for when neither flag is set", () => {
+    assert.deepEqual(resolvePositionsFlag({}), { value: undefined, defiMode: false });
+  });
+
+  it("maps --defi to --positions defi and flags DeFi-grouped output", () => {
+    assert.deepEqual(resolvePositionsFlag({ defi: true }), { value: "defi", defiMode: true });
+  });
+
+  it("accepts --defi alongside a redundant --positions defi", () => {
+    assert.deepEqual(
+      resolvePositionsFlag({ defi: true, positions: "defi" }),
+      { value: "defi", defiMode: true },
+    );
+  });
+
+  it("rejects --defi combined with a contradictory --positions", () => {
+    for (const positions of ["all", "simple"]) {
+      const { error } = resolvePositionsFlag({ defi: true, positions });
+      assert.equal(error.code, "conflicting_flags");
+      assert.match(error.message, new RegExp(positions));
+    }
+  });
+
+  it("passes explicit --positions values through without defiMode", () => {
+    assert.deepEqual(resolvePositionsFlag({ positions: "all" }), { value: "all", defiMode: false });
+    assert.deepEqual(resolvePositionsFlag({ positions: "defi" }), { value: "defi", defiMode: false });
+  });
+
+  it("still validates the --positions value", () => {
+    assert.equal(resolvePositionsFlag({ positions: "bogus" }).error.code, "unsupported_positions_filter");
+    assert.equal(resolvePositionsFlag({ positions: true }).error.code, "missing_positions_value");
   });
 });

--- a/cli/tests/unit/cli/utils/wallet/resolve-read-path.test.mjs
+++ b/cli/tests/unit/cli/utils/wallet/resolve-read-path.test.mjs
@@ -1,0 +1,220 @@
+// The read/sign split in resolveWallet (WLT-2076).
+//
+// Read commands funnel through resolveAddressOrWallet, which used to resolve
+// wallets with the same rules as `send`/`swap` — including a signing guard that
+// compared the wallet's ecosystem against a chain the user never asked for. A
+// saved Solana wallet therefore failed all five read commands with
+// `readonly_chain_mismatch` on the `ethereum` default.
+//
+// Uses a temp HOME so neither ~/.zerion nor ~/.ows is touched (CONFIG_DIR is
+// derived from HOME at import time, so HOME must be set before the imports).
+
+import assert from "node:assert/strict";
+import { describe, it, before, after } from "node:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+
+const EVM = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+const SOL = "ebDDhKWSBXPirnzXgFWTTArfymyG4n5fpg1Y5UgwNRY";
+
+let resolve;
+let ows;
+let config;
+let constants;
+let tmpHome;
+const origHome = process.env.HOME;
+
+before(async () => {
+  tmpHome = mkdtempSync(join(tmpdir(), "zerion-resolve-"));
+  process.env.HOME = tmpHome;
+  const readonly = await import("#zerion/utils/wallet/readonly.js");
+  readonly.addReadonly("ro-evm", EVM);
+  readonly.addReadonly("ro-sol", SOL);
+  ows = await import("#zerion/utils/wallet/keystore.js");
+  config = await import("#zerion/utils/config.js");
+  constants = await import("#zerion/utils/common/constants.js");
+  resolve = await import("#zerion/utils/wallet/resolve.js");
+});
+
+after(() => {
+  process.env.HOME = origHome;
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+class Exited extends Error {
+  constructor(code) {
+    super(`process.exit(${code})`);
+    this.code = code;
+  }
+}
+
+// resolveWallet reports failure with printError + process.exit rather than by
+// throwing, so intercept both to assert on the structured error.
+function runExpectingExit(fn) {
+  const origExit = process.exit;
+  const origWrite = process.stderr.write;
+  let stderr = "";
+  process.stderr.write = (chunk) => { stderr += chunk; return true; };
+  process.exit = (code) => { throw new Exited(code); };
+  try {
+    fn();
+    return { exited: false };
+  } catch (err) {
+    if (!(err instanceof Exited)) throw err;
+    return { exited: true, code: err.code, error: JSON.parse(stderr).error };
+  } finally {
+    process.exit = origExit;
+    process.stderr.write = origWrite;
+  }
+}
+
+describe("resolveWallet — read path, read-only Solana wallet", () => {
+  it("resolves with no --chain instead of failing on the ethereum default", () => {
+    const result = resolve.resolveWallet({ wallet: "ro-sol" }, [], { purpose: "read" });
+    assert.equal(result.address, SOL);
+    assert.equal(result.readOnly, true);
+  });
+
+  it("resolves when --chain solana is passed explicitly", () => {
+    const result = resolve.resolveWallet(
+      { wallet: "ro-sol", chain: "solana" }, [], { purpose: "read" },
+    );
+    assert.equal(result.address, SOL);
+  });
+
+  it("still reports a mismatch when an EVM --chain is asked for explicitly", () => {
+    const { exited, code, error } = runExpectingExit(() =>
+      resolve.resolveWallet({ wallet: "ro-sol", chain: "ethereum" }, [], { purpose: "read" }),
+    );
+    assert.ok(exited);
+    assert.equal(code, 1);
+    assert.equal(error.code, "readonly_chain_mismatch");
+    // Read wording — the old message blamed signing on a command that reads.
+    assert.match(error.message, /nothing to read/);
+    assert.doesNotMatch(error.message, /sign/);
+  });
+});
+
+describe("resolveWallet — read path, read-only EVM wallet", () => {
+  it("resolves with no --chain", () => {
+    const result = resolve.resolveWallet({ wallet: "ro-evm" }, [], { purpose: "read" });
+    assert.equal(result.address, EVM);
+  });
+
+  it("resolves under --chain base (any EVM chain matches)", () => {
+    const result = resolve.resolveWallet(
+      { wallet: "ro-evm", chain: "base" }, [], { purpose: "read" },
+    );
+    assert.equal(result.address, EVM);
+  });
+
+  it("reports a mismatch under an explicit --chain solana", () => {
+    const { error } = runExpectingExit(() =>
+      resolve.resolveWallet({ wallet: "ro-evm", chain: "solana" }, [], { purpose: "read" }),
+    );
+    assert.equal(error.code, "readonly_chain_mismatch");
+  });
+});
+
+describe("resolveWallet — sign path is unchanged", () => {
+  it("still refuses a Solana wallet on the ethereum default", () => {
+    const { error } = runExpectingExit(() => resolve.resolveWallet({ wallet: "ro-sol" }));
+    assert.equal(error.code, "readonly_chain_mismatch");
+    assert.match(error.message, /can't sign/);
+  });
+
+  it("still refuses an EVM wallet on --chain solana", () => {
+    const { error } = runExpectingExit(() =>
+      resolve.resolveWallet({ wallet: "ro-evm", chain: "solana" }),
+    );
+    assert.equal(error.code, "readonly_chain_mismatch");
+    assert.match(error.message, /can't sign on Solana/);
+  });
+
+  it("accepts a matching ecosystem", () => {
+    assert.equal(
+      resolve.resolveWallet({ wallet: "ro-sol", chain: "solana" }).address, SOL,
+    );
+    assert.equal(
+      resolve.resolveWallet({ wallet: "ro-evm", chain: "base" }).address, EVM,
+    );
+  });
+
+  it("defaults to sign rules when no purpose is given", () => {
+    // The 4 trading commands call resolveWallet(flags) with no options — the
+    // guard must not become opt-in.
+    const { exited } = runExpectingExit(() => resolve.resolveWallet({ wallet: "ro-sol" }, []));
+    assert.ok(exited, "sign guard did not fire without an explicit purpose");
+  });
+});
+
+describe("resolveAddress — name suffixes", () => {
+  it("explains that .sol is unsupported instead of falling through", async () => {
+    // Previously this fell through to the wallet-name lookup and reported
+    // `wallet_not_found`, telling the caller to audit a wallet list that never
+    // had the name in it.
+    await assert.rejects(
+      () => resolve.resolveAddress("toly.sol"),
+      (err) => {
+        assert.equal(err.code, "sns_not_supported");
+        assert.match(err.message, /base58/);
+        return true;
+      },
+    );
+  });
+
+  it("passes through raw addresses of both ecosystems", async () => {
+    assert.equal(await resolve.resolveAddress(EVM), EVM);
+    assert.equal(await resolve.resolveAddress(SOL), SOL);
+  });
+
+  it("tags an unrecognised string with invalid_address", async () => {
+    await assert.rejects(
+      () => resolve.resolveAddress("not-an-address"),
+      (err) => {
+        assert.equal(err.code, "invalid_address");
+        return true;
+      },
+    );
+  });
+});
+
+// OWS gives a `--sol-key` wallet an EVM account too, but its secp256k1 key is
+// generated at random — that 0x address belongs to nobody. Reading it returned
+// a stranger's empty portfolio with no error at all, which is worse than the
+// read-only case that at least failed loudly.
+describe("resolveWallet — read path, --sol-key keystore wallet", () => {
+  let solAddress;
+  let randomEvmAddress;
+
+  before(() => {
+    const wallet = ows.importFromKey(
+      "solonly", randomBytes(32).toString("hex"), undefined, "solana",
+    );
+    config.setWalletOrigin("solonly", constants.WALLET_ORIGIN.SOL_KEY);
+    solAddress = wallet.solAddress;
+    randomEvmAddress = wallet.evmAddress;
+  });
+
+  it("reads the owned Solana account, not the random EVM one", () => {
+    const result = resolve.resolveWallet({ wallet: "solonly" }, [], { purpose: "read" });
+    assert.equal(result.address, solAddress);
+    assert.notEqual(result.address, randomEvmAddress);
+  });
+
+  it("refuses an explicit EVM --chain rather than reading the random address", () => {
+    const { error } = runExpectingExit(() =>
+      resolve.resolveWallet({ wallet: "solonly", chain: "ethereum" }, [], { purpose: "read" }),
+    );
+    assert.equal(error.code, "no_account_for_chain");
+  });
+
+  it("reads under --chain solana", () => {
+    const result = resolve.resolveWallet(
+      { wallet: "solonly", chain: "solana" }, [], { purpose: "read" },
+    );
+    assert.equal(result.address, solAddress);
+  });
+});

--- a/cli/utils/api/client.js
+++ b/cli/utils/api/client.js
@@ -139,9 +139,15 @@ export async function fetchAPI(pathname, params = {}, auth) {
 
 // --- Wallet endpoints ---
 
+// `filter[positions]` defaults to `only_simple` server-side, which silently
+// drops every DeFi position from the total — so the CLI disagreed with the
+// Zerion app on any wallet holding DeFi (WLT-2076). Ask for the aggregated
+// view instead. Unlike `/positions/`, this endpoint accepts `no_filter` for
+// Solana addresses too, so it needs no ecosystem guard.
 export async function getPortfolio(address, options = {}) {
   return fetchAPI(`/wallets/${encodeURIComponent(address)}/portfolio`, {
     currency: options.currency || "usd",
+    "filter[positions]": options.positionFilter || "no_filter",
   }, options.auth);
 }
 

--- a/cli/utils/chain/address.js
+++ b/cli/utils/chain/address.js
@@ -1,0 +1,21 @@
+/**
+ * Address shape helpers — which ecosystem does a raw address string belong to?
+ *
+ * Deliberately dependency-free (no viem, unlike ./registry.js) so the API
+ * client can import it without dragging a chain SDK into every read command.
+ *
+ * These are *shape* checks, not validity checks: enough to route a request or
+ * pick an account, not enough to prove an address exists or is spendable.
+ */
+
+export const EVM_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+// Solana pubkeys are base58 (no 0, O, I, l) and 43–44 chars once encoded.
+export const SOL_ADDRESS_RE = /^[1-9A-HJ-NP-Za-km-z]{43,44}$/;
+
+export function isEvmAddress(value) {
+  return typeof value === "string" && EVM_ADDRESS_RE.test(value);
+}
+
+export function isSolanaAddress(value) {
+  return typeof value === "string" && SOL_ADDRESS_RE.test(value);
+}

--- a/cli/utils/common/analyze.js
+++ b/cli/utils/common/analyze.js
@@ -3,7 +3,16 @@
  * into a concise summary (portfolio, top positions, recent txs, PnL).
  */
 
-export function summarizeAnalyze(address, portfolio, positions, transactions, pnl) {
+import { portfolioTotals } from "./portfolio.js";
+
+export function summarizeAnalyze(address, portfolio, positions, transactions, pnl, options = {}) {
+  const chainId = options.chainId ?? null;
+  const attrs = portfolio?.data?.attributes;
+  // With --chain the total is that chain's slice and the 24h change is dropped:
+  // the API publishes changes wallet-wide only. `chains` stays whole so a caller
+  // can still see where the rest of the value sits.
+  const totals = portfolioTotals(attrs, chainId);
+
   const topPositions = Array.isArray(positions?.data)
     ? positions.data
         .sort((a, b) => (b.attributes?.value ?? 0) - (a.attributes?.value ?? 0))
@@ -40,10 +49,11 @@ export function summarizeAnalyze(address, portfolio, positions, transactions, pn
   return {
     wallet: { query: address },
     portfolio: {
-      total: portfolio?.data?.attributes?.total?.positions ?? null,
+      total: totals.total,
       currency: "usd",
-      change_1d: portfolio?.data?.attributes?.changes ?? null,
-      chains: portfolio?.data?.attributes?.positions_distribution_by_chain ?? null,
+      change_1d: chainId ? null : (attrs?.changes ?? null),
+      chains: attrs?.positions_distribution_by_chain ?? null,
+      ...(chainId ? { chain: chainId } : {}),
     },
     positions: {
       count: Array.isArray(positions?.data) ? positions.data.length : 0,

--- a/cli/utils/common/format.js
+++ b/cli/utils/common/format.js
@@ -34,6 +34,14 @@ function usd(value) {
   return `$${Number(value).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 }
 
+// A signed dollar delta (e.g. a 24h change), coloured like a percentage.
+function usdDelta(value) {
+  if (value == null) return "-";
+  const n = Number(value);
+  const color = n >= 0 ? GREEN : RED;
+  return `${color}${n >= 0 ? "+" : "-"}${usd(Math.abs(n))}${RESET}`;
+}
+
 function pct(value) {
   if (value == null) return "-";
   const n = Number(value);
@@ -97,18 +105,44 @@ export function formatSearch(data) {
   return lines.join("\n");
 }
 
+// Structured `notes` (e.g. the Solana "token holdings only" downgrade) exist to
+// explain a result that would otherwise look wrong. JSON consumers read them off
+// the payload; pretty mode has to print them or humans — the ones likely to ask
+// where their DeFi went — never see them.
+function noteLines(data) {
+  const notes = data.notes ?? [];
+  if (!notes.length) return [];
+  return [...notes.map((n) => `  ${DIM}ⓘ ${n}${RESET}`), ""];
+}
+
 export function formatPortfolio(data) {
+  const scope = data.chain ? ` ${DIM}· ${data.chain}${RESET}` : "";
   const lines = [
-    `${BOLD}Portfolio${RESET} — ${data.wallet.name} ${DIM}(${data.wallet.address.slice(0, 8)}...)${RESET}\n`,
-    `  Total: ${BOLD}${usd(data.portfolio.total)}${RESET}  24h: ${pct(data.portfolio.change_24h)}\n`,
+    `${BOLD}Portfolio${RESET} — ${data.wallet.name} ${DIM}(${data.wallet.address.slice(0, 8)}...)${RESET}${scope}\n`,
+    // change_24h is `changes.absolute_1d` — dollars, not a percentage. It was
+    // being rendered through pct(), which printed a $4,048 move as "-4048.26%".
+    `  Total: ${BOLD}${usd(data.portfolio.total)}${RESET}  24h: ${usdDelta(data.portfolio.change_24h)}\n`,
+    ...noteLines(data),
   ];
 
   if (data.positions.length > 0) {
-    lines.push(`  ${DIM}${pad("Token", 16)} ${pad("Chain", 12)} ${padStart("Value", 12)} ${padStart("Amount", 16)}${RESET}`);
-    lines.push(`  ${DIM}${"─".repeat(58)}${RESET}`);
+    // The total includes DeFi, so the list does too — label the protocol rows,
+    // or a staked ETH row is indistinguishable from the wallet ETH row above it.
+    const hasDefi = data.positions.some((p) => p.position_type && p.position_type !== "wallet");
+    const typeHeader = hasDefi ? ` ${pad("Type", 10)} Protocol` : "";
+    lines.push(`  ${DIM}${pad("Token", 16)} ${pad("Chain", 12)} ${padStart("Value", 12)} ${padStart("Amount", 16)}${typeHeader}${RESET}`);
+    lines.push(`  ${DIM}${"─".repeat(hasDefi ? 80 : 58)}${RESET}`);
     for (const p of data.positions) {
+      // A plain holding gets blanks, not a "[—]" badge: the column exists to
+      // mark the protocol rows, and most rows are ordinary token balances.
+      const isProtocolRow = p.position_type && p.position_type !== "wallet";
+      const typeCol = !hasDefi
+        ? ""
+        : isProtocolRow
+          ? ` ${positionTypeBadge(p.position_type)} ${p.protocol || ""}`.trimEnd()
+          : ` ${pad("", 10)}`;
       lines.push(
-        `  ${pad(p.symbol || "?", 16)} ${pad(p.chain || "?", 12)} ${padStart(usd(p.value), 12)} ${padStart(p.quantity?.toFixed(4) || "-", 16)}`
+        `  ${pad(p.symbol || "?", 16)} ${pad(p.chain || "?", 12)} ${padStart(usd(p.value), 12)} ${padStart(p.quantity?.toFixed(4) || "-", 16)}${typeCol}`
       );
     }
   }
@@ -119,6 +153,7 @@ export function formatPositions(data) {
   const walletLabel = data.wallet.name || data.wallet.address.slice(0, 10) + "...";
   const lines = [
     `${BOLD}Positions${RESET} — ${walletLabel} (${data.count})\n`,
+    ...noteLines(data),
     `  ${DIM}${pad("Token", 16)} ${pad("Chain", 12)} ${padStart("Value", 12)} ${padStart("24h", 18)} ${padStart("Amount", 16)}${RESET}`,
     `  ${DIM}${"─".repeat(76)}${RESET}`,
   ];

--- a/cli/utils/common/portfolio.js
+++ b/cli/utils/common/portfolio.js
@@ -1,0 +1,28 @@
+/**
+ * Portfolio totals — reading the `/portfolio` attributes coherently.
+ *
+ * The endpoint takes no chain filter, so a `--chain` narrows the *position
+ * list* but not the total. Reporting the wallet-wide number above a one-chain
+ * list is the bug this helper exists to prevent: take that chain's slice of
+ * `positions_distribution_by_chain` instead, and drop the 24h change, which the
+ * API only publishes wallet-wide (WLT-2076).
+ *
+ * The distribution's keys are the same chain ids the catalog resolves `--chain`
+ * to, so a chain the wallet holds nothing on is simply absent.
+ *
+ * A missing total stays `null` — "the API didn't tell us" is not the same claim
+ * as "$0", so callers that need a number to render apply their own default.
+ */
+export function portfolioTotals(attributes, chainId) {
+  const attrs = attributes ?? {};
+  if (!chainId) {
+    return {
+      total: attrs.total?.positions ?? null,
+      change24h: attrs.changes?.absolute_1d ?? null,
+    };
+  }
+  return {
+    total: attrs.positions_distribution_by_chain?.[chainId] ?? null,
+    change24h: null,
+  };
+}

--- a/cli/utils/common/validate.js
+++ b/cli/utils/common/validate.js
@@ -9,6 +9,7 @@
  */
 
 import { isSolana, toCaip2 } from "../chain/registry.js";
+import { isSolanaAddress } from "../chain/address.js";
 import { resolveChain, listTradingChainIds, listBridgeChainIds, listSendingChainIds } from "../chain/catalog.js";
 
 const CHAINS_HINT = "Run `zerion chains` for the live list of supported chains and their capabilities.";
@@ -40,6 +41,46 @@ export function validatePositions(flag) {
 
 export function resolvePositionFilter(flag) {
   return POSITION_FILTERS[flag] || "no_filter";
+}
+
+/**
+ * Pick the `filter[positions]` value to send for one specific address.
+ *
+ * The Zerion API has no protocol (DeFi) positions for Solana yet, and
+ * `/positions/` hard-rejects both `no_filter` and `only_complex` for base58
+ * addresses with a 400 ("currently not supported for Solana addresses").
+ * `only_simple` is the only value it accepts. EVM addresses take all three.
+ *
+ * So on Solana:
+ *   - `--positions defi` / `--defi` asks for something that cannot exist —
+ *     a structured error beats silently handing back token holdings.
+ *   - `all` or unset already means "everything there is", and on Solana that
+ *     *is* the simple set — downgrade quietly but say so in the output.
+ *   - `simple` is already the only supported value.
+ *
+ * Returns `{ filter, note }` or `{ error }` — exactly one of filter/error set.
+ */
+export function resolvePositionFilterForAddress(address, flag) {
+  const filter = resolvePositionFilter(flag);
+  if (!isSolanaAddress(address) || filter === "only_simple") return { filter };
+
+  if (filter === "only_complex") {
+    return {
+      error: {
+        code: "solana_defi_unsupported",
+        message:
+          "Solana addresses have no DeFi positions in the Zerion API yet, " +
+          "so there is nothing for --positions defi to return.",
+        suggestion:
+          "Drop --defi/--positions defi to see token holdings, or query an EVM address.",
+      },
+    };
+  }
+
+  return {
+    filter: "only_simple",
+    note: "Solana has no DeFi positions in the Zerion API yet — showing token holdings only.",
+  };
 }
 
 const TRADING_CAPABILITIES = {

--- a/cli/utils/common/validate.js
+++ b/cli/utils/common/validate.js
@@ -44,6 +44,34 @@ export function resolvePositionFilter(flag) {
 }
 
 /**
+ * Normalise the two ways a caller can ask for DeFi: `--positions defi` and the
+ * `--defi` shorthand. Both `positions` and `analyze` accept them, so the
+ * shorthand lives here rather than in one command — `analyze --defi` used to be
+ * dropped on the floor because only `positions` knew about the flag.
+ *
+ * Returns `{ value, defiMode }` or `{ error }`. `value` is the effective
+ * `--positions` value (`undefined` when nothing was asked for); `defiMode` says
+ * whether the caller wants DeFi-grouped output, which only `positions` renders.
+ */
+export function resolvePositionsFlag(flags = {}) {
+  const defiMode = Boolean(flags.defi);
+  if (defiMode && flags.positions && flags.positions !== "defi") {
+    return {
+      error: {
+        code: "conflicting_flags",
+        message: `--defi cannot be combined with --positions ${flags.positions}. Use one or the other.`,
+      },
+    };
+  }
+
+  const value = defiMode ? "defi" : flags.positions;
+  const invalid = validatePositions(value);
+  if (invalid) return { error: invalid };
+
+  return { value, defiMode };
+}
+
+/**
  * Pick the `filter[positions]` value to send for one specific address.
  *
  * The Zerion API has no protocol (DeFi) positions for Solana yet, and

--- a/cli/utils/wallet/resolve.js
+++ b/cli/utils/wallet/resolve.js
@@ -5,8 +5,9 @@
 import { createPublicClient, http } from "viem";
 import { mainnet } from "viem/chains";
 import * as ows from "./keystore.js";
-import { getConfigValue } from "../config.js";
+import { getConfigValue, getWalletOrigin, getWalletAddresses } from "../config.js";
 import { isSolana } from "../chain/registry.js";
+import { isEvmAddress, isSolanaAddress } from "../chain/address.js";
 import { printError } from "../common/output.js";
 import { resolveWatchAddress } from "./watchlist.js";
 import { getReadonly } from "./readonly.js";
@@ -45,7 +46,7 @@ async function resolveEns(name) {
 }
 
 export async function resolveAddress(input) {
-  if (/^0x[0-9a-fA-F]{40}$/.test(input)) return input;
+  if (isEvmAddress(input)) return input;
   // Check local wallets first — handles names like "test.zerion.eth"
   try {
     return ows.getEvmAddress(input);
@@ -55,12 +56,41 @@ export async function resolveAddress(input) {
     if (!resolved) throw new Error(`Could not resolve ENS name: ${input}`);
     return resolved;
   }
-  // Solana public keys: 44-character base58
-  if (/^[1-9A-HJ-NP-Za-km-z]{43,44}$/.test(input)) return input;
-  throw new Error(`Invalid address: "${input}". Expected a 0x address, ENS name (.eth), or Solana address.`);
+  // Solana Name Service is not wired up. Say so instead of falling through to
+  // the wallet-name lookup, which reports `wallet_not_found` and sends the
+  // caller off to audit their wallet list over a name it never had (WLT-2076).
+  if (input.endsWith(".sol")) {
+    const err = new Error(
+      `Solana Name Service (.sol) names are not supported yet — only ENS (.eth) resolves. ` +
+      `Pass the base58 Solana address for "${input}" instead.`
+    );
+    err.code = "sns_not_supported";
+    throw err;
+  }
+  // Solana public keys: 43–44 character base58
+  if (isSolanaAddress(input)) return input;
+  const err = new Error(
+    `Invalid address: "${input}". Expected a 0x address, ENS name (.eth), or Solana address.`
+  );
+  err.code = "invalid_address";
+  throw err;
 }
 
-export function resolveWallet(flags, args = []) {
+/**
+ * Resolve `flags`/`args` to a wallet name + address.
+ *
+ * `options.purpose` picks the ecosystem rules:
+ *   - `"sign"` (default) — the address must be able to sign on `chain`, so an
+ *     ecosystem mismatch is fatal and the chain always resolves to a concrete
+ *     default. Used by send/swap/bridge/consolidate.
+ *   - `"read"` — nothing is signed, so the wallet's ecosystem need not match
+ *     the chain. Only an *explicit* `--chain` can conflict; the `ethereum`
+ *     default never does. Used by the analytics commands via
+ *     `resolveAddressOrWallet`.
+ */
+export function resolveWallet(flags, args = [], options = {}) {
+  const forRead = options.purpose === "read";
+
   // If --watch is passed, resolve from watchlist
   if (flags.watch) {
     const address = resolveWatchAddress(flags.watch);
@@ -82,20 +112,29 @@ export function resolveWallet(flags, args = []) {
     process.exit(1);
   }
 
-  // Determine chain to pick the right address type
-  const chain = flags.chain || flags["from-chain"] || getConfigValue("defaultChain") || "ethereum";
+  // Determine chain to pick the right address type. On the read path an
+  // unset --chain stays unset: "no chain asked for" and "defaulted to ethereum"
+  // must not be conflated, or every Solana wallet looks like a mismatch.
+  const explicitChain = flags.chain || flags["from-chain"];
+  const chain = explicitChain || getConfigValue("defaultChain") || "ethereum";
 
   // Read-only "my wallet": no key material, address-only. Signing always routes
   // to the web-app handoff. The stored address's ecosystem (EVM 0x vs Solana
-  // base58) must match the requested chain — refuse a mismatch rather than
-  // resolving an address the connected wallet can't sign for.
+  // base58) must match the chain being signed for — refuse a mismatch rather
+  // than resolving an address the connected wallet can't sign for. Reading is
+  // unconstrained: the Zerion API takes either address shape, so only an
+  // explicit --chain can conflict there (WLT-2076).
   const ro = getReadonly(walletName);
   if (ro) {
-    const roIsSolana = SOL_ADDR_RE.test(ro.address);
-    if (isSolana(chain) !== roIsSolana) {
+    const roIsSolana = isSolanaAddress(ro.address);
+    const comparedChain = forRead ? explicitChain : chain;
+    if (comparedChain && isSolana(comparedChain) !== roIsSolana) {
+      const kind = roIsSolana ? "a Solana" : "an EVM";
+      const target = isSolana(comparedChain) ? "Solana" : `EVM chain "${comparedChain}"`;
       printError("readonly_chain_mismatch",
-        `Read-only wallet "${walletName}" is a ${roIsSolana ? "Solana" : "EVM"} address; ` +
-        `it can't sign on ${isSolana(chain) ? "Solana" : `EVM chain "${chain}"`}.`,
+        forRead
+          ? `Read-only wallet "${walletName}" is ${kind} address; there is nothing to read for it on ${target}.`
+          : `Read-only wallet "${walletName}" is ${kind} address; it can't sign on ${target}.`,
         { suggestion: roIsSolana ? "Use --chain solana." : "Use an EVM --chain." }
       );
       process.exit(1);
@@ -104,27 +143,69 @@ export function resolveWallet(flags, args = []) {
   }
 
   try {
-    let address;
-    if (isSolana(chain)) {
-      address = ows.getSolAddress(walletName);
-      if (!address) throw new Error("No Solana address");
-    } else {
-      address = ows.getEvmAddress(walletName);
-    }
-    return { walletName, address };
+    return { walletName, address: forRead
+      ? readAddressFor(walletName, explicitChain)
+      : signAddressFor(walletName, chain) };
   } catch (err) {
-    const code = err.message?.includes("not found") ? "wallet_not_found" : "ows_error";
+    const code = err.code
+      || (err.message?.includes("not found") ? "wallet_not_found" : "ows_error");
     printError(code, code === "wallet_not_found"
       ? `Wallet "${walletName}" not found`
-      : `Wallet error: ${err.message}`, {
+      : code === "ows_error" ? `Wallet error: ${err.message}` : err.message, {
       suggestion: "List wallets with: zerion wallet list",
     });
     process.exit(1);
   }
 }
 
-const SOL_ADDR_RE = /^[1-9A-HJ-NP-Za-km-z]{43,44}$/;
-const EVM_ADDR_RE = /^0x[0-9a-fA-F]{40}$/;
+function signAddressFor(walletName, chain) {
+  if (!isSolana(chain)) return ows.getEvmAddress(walletName);
+  const address = ows.getSolAddress(walletName);
+  if (!address) throw new Error("No Solana address");
+  return address;
+}
+
+/**
+ * Pick the address to *read* for a keystore wallet.
+ *
+ * Not simply "the account for `chain`": a wallet imported with `--sol-key`
+ * still gets an EVM account, but its secp256k1 key was generated at random, so
+ * that 0x address is a stranger's and reading it silently reports an empty
+ * portfolio. `walletOrigins` records which side the user actually owns, and
+ * `getWalletAddresses` is the existing filter for it — reuse it rather than
+ * trusting that an account merely exists.
+ */
+function readAddressFor(walletName, explicitChain) {
+  const { evmAddress, solAddress } = getWalletAddresses(
+    ows.getWallet(walletName),
+    getWalletOrigin(walletName),
+  );
+
+  if (explicitChain) {
+    const wantSolana = isSolana(explicitChain);
+    const address = wantSolana ? solAddress : evmAddress;
+    if (!address) {
+      const err = new Error(
+        `Wallet "${walletName}" has no ${wantSolana ? "Solana" : "EVM"} account, ` +
+        `so there is nothing to read on chain "${explicitChain}".`
+      );
+      err.code = "no_account_for_chain";
+      throw err;
+    }
+    return address;
+  }
+
+  // No --chain asked for: return whichever account the wallet owns, EVM first
+  // since that's the common case for a multi-account (mnemonic) wallet.
+  const address = evmAddress || solAddress;
+  if (!address) {
+    const err = new Error(`Wallet "${walletName}" has no readable account.`);
+    err.code = "ows_error";
+    throw err;
+  }
+  return address;
+}
+
 
 /**
  * Resolve a destination address for cross-chain bridges/swaps. Picks the right
@@ -143,7 +224,7 @@ export async function resolveDestination({ toAddressOrEns, toWalletName, fallbac
 
   if (toAddressOrEns) {
     if (wantsSolana) {
-      if (!SOL_ADDR_RE.test(toAddressOrEns)) {
+      if (!isSolanaAddress(toAddressOrEns)) {
         throw new Error(
           `--to-address ${toAddressOrEns} is not a Solana address. ` +
           `Solana destinations need a base58 Solana pubkey.`
@@ -151,7 +232,7 @@ export async function resolveDestination({ toAddressOrEns, toWalletName, fallbac
       }
       return { address: toAddressOrEns, source: "address" };
     }
-    if (EVM_ADDR_RE.test(toAddressOrEns) || toAddressOrEns.endsWith(".eth")) {
+    if (isEvmAddress(toAddressOrEns) || toAddressOrEns.endsWith(".eth")) {
       const resolved = await resolveAddress(toAddressOrEns);
       return { address: resolved, source: "address" };
     }
@@ -199,19 +280,42 @@ export async function resolveDestination({ toAddressOrEns, toWalletName, fallbac
   return { address: evmAddress, source: "wallet", walletName: lookupWallet };
 }
 
+// Does this positional arg look like an address rather than a wallet name?
+// `.sol` counts deliberately: it is not resolvable, but routing it here lets
+// resolveAddress explain that instead of the caller reporting it as a missing
+// wallet name.
+function looksLikeAddress(value) {
+  return value.startsWith("0x")
+    || value.endsWith(".eth")
+    || value.endsWith(".sol")
+    || isSolanaAddress(value);
+}
+
 /**
  * Resolve address from positional arg or --wallet/--address/--watch flags.
  * Supports both `wallet portfolio <addr>` and `portfolio --wallet <name>`.
+ *
+ * This is the read path — every analytics command funnels through it — so it
+ * resolves wallets with `purpose: "read"`: no signing happens here, and the
+ * wallet's ecosystem need not match any chain.
  */
 export async function resolveAddressOrWallet(args, flags) {
-  if (args[0] && (args[0].startsWith("0x") || args[0].endsWith(".eth") || /^[1-9A-HJ-NP-Za-km-z]{43,44}$/.test(args[0]))) {
-    const address = await resolveAddress(args[0]);
-    return { walletName: args[0], address };
+  try {
+    if (args[0] && looksLikeAddress(args[0])) {
+      const address = await resolveAddress(args[0]);
+      return { walletName: args[0], address };
+    }
+    const resolved = resolveWallet(flags, args, { purpose: "read" });
+    let address = resolved.address;
+    if (resolved.needsResolve) {
+      address = await resolveAddress(address);
+    }
+    return { walletName: resolved.walletName, address };
+  } catch (err) {
+    // Commands call this before their own try/catch, so an address-resolution
+    // failure would otherwise surface as a bare `unexpected_error`. Emit the
+    // structured code the error already carries.
+    printError(err.code || "address_resolve_failed", err.message);
+    process.exit(1);
   }
-  const resolved = resolveWallet(flags, args);
-  let address = resolved.address;
-  if (resolved.needsResolve) {
-    address = await resolveAddress(address);
-  }
-  return { walletName: resolved.walletName, address };
 }

--- a/skills/zerion/SKILL.md
+++ b/skills/zerion/SKILL.md
@@ -190,7 +190,7 @@ Use `zerion chains` for the live catalog with metadata.
 | `no_wallet` | No wallet specified, no default | `--wallet <name>` or set `defaultWallet` config |
 | `wallet_not_found` | Wallet not in local vault | `zerion wallet list` to check |
 | `unsupported_chain` | Invalid `--chain` value | `zerion chains` for valid IDs |
-| `readonly_chain_mismatch` | Read-only wallet's address format doesn't match the chain | An EVM (`0x…`) read-only wallet can't sign on Solana, and vice versa |
+| `readonly_chain_mismatch` | Read-only wallet's address format doesn't match an explicitly requested chain | An EVM (`0x…`) read-only wallet can't sign on Solana, and vice versa. Read commands need no `--chain` |
 | `api_error` 401 | Invalid API key | Check key at dashboard.zerion.io |
 | `api_error` 429 | Rate limited | Wait, lower frequency, or switch to x402 |
 

--- a/skills/zerion/capabilities/analyze.md
+++ b/skills/zerion/capabilities/analyze.md
@@ -32,11 +32,14 @@ For execution (swap/bridge/send) → `capabilities/trading.md`. For wallet creat
 zerion analyze <address|name>
 zerion analyze <address|name> --chain <chain>
 zerion analyze <address|name> --positions all|simple|defi
+zerion analyze <address|name> --defi                # same as --positions defi
 zerion analyze <address|name> --limit <n>           # txs to sample (default 10)
 zerion analyze <address|name> --x402                # pay-per-call
 ```
 
 Fetches portfolio + positions + transactions + PnL in parallel. Returns a summary with portfolio total + chain breakdown + 1-day change, top 10 positions by value, 5 most recent transactions, and PnL totals.
+
+With `--chain`, every leg is scoped to that chain: `portfolio.total` becomes that chain's slice, `portfolio.chain` names it, and `change_1d` is `null` (the API publishes changes wallet-wide only). `portfolio.chains` still carries the full breakdown.
 
 ## Targeted reads
 
@@ -164,4 +167,6 @@ Empty positions/history usually means the wallet is inactive or very new — not
 
 ## Totals include DeFi
 
-`portfolio` and `analyze` report the **aggregated** total — wallet tokens plus DeFi (deposited, staked, locked, borrowed) — so the number matches the Zerion app. With `--chain`, `portfolio` reports that chain's slice of the total and omits the 24h change, which the API only publishes wallet-wide.
+`portfolio` and `analyze` report the **aggregated** total — wallet tokens plus DeFi (deposited, staked, locked, borrowed) — so the number matches the Zerion app. With `--chain`, both report that chain's slice of the total and omit the 24h change, which the API only publishes wallet-wide.
+
+Because the total includes DeFi, `portfolio`'s position rows do too: each row carries `position_type` (`wallet`, `deposit`, `staked`, `locked`, `loan`, `reward`) and `protocol`. Two rows for the same token — held plus staked — are two distinct positions, not a double count.

--- a/skills/zerion/capabilities/analyze.md
+++ b/skills/zerion/capabilities/analyze.md
@@ -1,7 +1,9 @@
 
 # Zerion — Wallet Analysis
 
-Read-only insights into any crypto wallet across 14 EVM chains and Solana. All commands accept `0x...` addresses, ENS names (e.g. `vitalik.eth`), local wallet names, or watched addresses.
+Read-only insights into any crypto wallet across 14 EVM chains and Solana. All commands accept `0x...` addresses, base58 Solana addresses, ENS names (e.g. `vitalik.eth`), saved wallet names (keystore or read-only, either ecosystem), or watched addresses.
+
+**Name resolution is ENS-only.** `.eth` resolves; `.sol` (Solana Name Service) does not and reports `sns_not_supported` — pass the base58 address instead.
 
 ## Setup
 
@@ -93,6 +95,16 @@ Key behaviors:
 - **`position_type`** ∈ `deposit | loan | staked | locked | reward | wallet | investment` — tag each row for downstream filtering.
 - Combining `--defi` with `--positions all|simple` errors with `conflicting_flags`.
 
+## Solana limitations
+
+The Zerion API has no protocol (DeFi) positions for Solana yet, so on a base58 address:
+
+- `positions` / `analyze` return **token holdings only**, and add a `notes` entry saying so. No flag needed — the CLI picks the filter the API accepts.
+- `--defi` / `--positions defi` errors with `solana_defi_unsupported`, because there is nothing for it to return. Don't retry it with a different filter; the wallet has no DeFi to find.
+- `portfolio`, `history`, and `pnl` work exactly as they do on EVM.
+
+Everything else is symmetric: a Solana wallet saved with `wallet add` reads by name with no `--chain` flag, same as an EVM one.
+
 ## Token search (find a contract address)
 
 ```bash
@@ -141,7 +153,15 @@ JSON on stdout, structured errors on stderr. See the parent `SKILL.md` (Setup + 
 | `unsupported_chain` | Invalid `--chain` | `zerion chains` for valid IDs |
 | `unsupported_positions_filter` | Invalid `--positions` | Use `all`, `simple`, or `defi` |
 | `conflicting_flags` | `--defi` combined with `--positions all\|simple` | Pick one — `--defi` already implies `--positions defi` |
+| `solana_defi_unsupported` | `--defi`/`--positions defi` on a Solana address | Drop the flag — Solana has no DeFi positions in the API yet |
+| `sns_not_supported` | A `.sol` name was passed | Only ENS (`.eth`) resolves; pass the base58 address |
+| `readonly_chain_mismatch` | An explicit `--chain` contradicts a saved wallet's ecosystem | Drop `--chain`, or match it to the wallet (`--chain solana` for a Solana wallet) |
+| `no_account_for_chain` | Saved wallet has no account on the requested `--chain` | Drop `--chain`, or use a wallet with that account |
 | `api_error` 429 | Rate limited | Wait, reduce frequency, or switch to `--x402` |
 | `api_error` 400 | Invalid address or ENS resolution failure | Retry with the resolved 0x address |
 
 Empty positions/history usually means the wallet is inactive or very new — not an error.
+
+## Totals include DeFi
+
+`portfolio` and `analyze` report the **aggregated** total — wallet tokens plus DeFi (deposited, staked, locked, borrowed) — so the number matches the Zerion app. With `--chain`, `portfolio` reports that chain's slice of the total and omits the 24h change, which the API only publishes wallet-wide.

--- a/skills/zerion/capabilities/wallet.md
+++ b/skills/zerion/capabilities/wallet.md
@@ -64,8 +64,10 @@ worth knowing before you plan a flow:
 
 - Trades on a read-only wallet **cannot run unattended** — a human has to sign in the browser.
 - No agent token is needed on the handoff path (there's no keystore to unlock).
-- The stored address's ecosystem fixes which chains it can sign for — an EVM (`0x…`) read-only wallet
-  refuses `--chain solana` with `readonly_chain_mismatch`, and vice versa.
+- The stored address's ecosystem fixes which chains it can **sign** for — an EVM (`0x…`) read-only wallet
+  refuses `--chain solana` with `readonly_chain_mismatch`, and vice versa. This is a signing constraint
+  only: read commands take either ecosystem and need no `--chain` at all (`zerion portfolio my-sol-wallet`
+  works). Passing a `--chain` that contradicts the wallet is still reported, since there'd be nothing to read.
 - `wallet backup` / `wallet export-key` error clearly — there is no key material to export.
 - `consolidate --execute` signs locally and so **cannot work** on a read-only wallet — it still demands
   an agent token first (`no_agent_token`, exit 1, if none is configured), and once past that gate every
@@ -194,5 +196,5 @@ After step 1's agent-token prompt, the wallet is ready for autonomous trading vi
 | `name_in_use` | `wallet add` name already taken by a keystore wallet | Pick another `--name` |
 | `readonly_invalid_address` | `wallet add` value isn't a 0x address, `.eth` name, or base58 pubkey | Check the address format |
 | `ens_resolve_failed` | ENS name didn't resolve to an EVM address | Verify the name, or pass the raw `0x` address |
-| `readonly_chain_mismatch` | Read-only wallet's ecosystem ≠ the requested chain | EVM wallet → EVM `--chain`; Solana wallet → `--chain solana` |
+| `readonly_chain_mismatch` | Read-only wallet's ecosystem ≠ an **explicitly requested** chain | EVM wallet → EVM `--chain`; Solana wallet → `--chain solana`. Reads need no `--chain` at all |
 | `invalid_threshold` | `set-review-threshold` value isn't a non-negative USD number or `off` | e.g. `500` or `off` |


### PR DESCRIPTION
Dogfooding hit three failures before one Solana read worked, and the CLI disagreed with the app on any wallet holding DeFi.

Portfolio dropped DeFi. `getPortfolio` never sent `filter[positions]`, so the API applied its `only_simple` default and every protocol position fell out of the total (vitalik.eth: $1,114,702 vs $1,122,524). Send `no_filter`. The ticket suggested detecting DeFi first and only then widening the filter, but `/portfolio` accepts `no_filter` for Solana addresses too — only `/positions/` rejects it — so no branching is needed. `portfolio` and `analyze` were also pairing an only_simple total with a no_filter position list; both now agree.

Saved Solana wallets failed all five read commands with `readonly_chain_mismatch`. The ecosystem check is a signing constraint, but it sat on the read path and compared against a `chain` that had defaulted to ethereum rather than anything the user asked for. resolveWallet takes a `purpose` option: reads skip the guard unless an explicit --chain conflicts, signing is unchanged. The read path also honours `walletOrigins` — a `--sol-key` wallet gets a randomly generated EVM account from OWS, so reading it by name silently reported an unrelated empty address.

`positions` was dead on Solana: the API rejects both `no_filter` and `only_complex` there. One helper now decides the filter per address — downgrade an implicit "everything" to `only_simple` with a note, refuse an explicit `--defi` with `solana_defi_unsupported` rather than quietly substituting token holdings.

Also fixed, same flows:
- `.sol` names reported `wallet_not_found` and pointed at `zerion wallet list`; they now report `sns_not_supported` and ask for the base58 address.
- `portfolio --chain X` printed an all-chain total above a one-chain position list; it now reports that chain's slice and omits the 24h change, which the API only publishes wallet-wide.
- `portfolio` and `history` were missed by 2b576c0 and passed --chain through unvalidated, surfacing a raw 400 instead of `unsupported_chain`.
- Address-resolution failures on the read path surfaced as `unexpected_error`.

Docs: `wallet.md` claimed read commands work normally on read-only wallets, which was false for Solana ones; `readonly_chain_mismatch` was documented in three places as signing-only while it blocked reads; `analyze.md` never mentioned the Solana filter limitation or that `.sol` does not resolve.

Tests: none of these paths had coverage. Adds unit tests for the filter defaults on the wire, the per-address filter decision, the read/sign split (including that the sign guard stays on by default), the `--sol-key` address pick, and the address-shape helpers.