### PR TITLE
feat(skills): add treasury-liquidation skill with gas-aware sweeps

### DIFF
--- a/skills/treasury-liquidation/SKILL.md
+++ b/skills/treasury-liquidation/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: treasury-liquidation
+description: Move and liquidate crypto treasury holdings across many chains with the zerion CLI. Two composable phases - (1) drain every token above a floor from one wallet to another across all chains via raw transfers, preserving asset identity, and (2) convert a wallet's entire multi-chain portfolio into USDC on one destination chain, keeping a gas reserve on each chain. Use when asked to drain, sweep, consolidate, liquidate, or "send everything" / "swap everything into USDC" for a wallet, to move a treasury between addresses, or to clean up dust and long-tail tokens across chains.
+---
+
+# Treasury liquidation
+
+Two phases. They compose (drain A→B, then liquidate B) or run independently.
+
+**Phase 1 — drain.** Send every token above a floor from wallet A to wallet B,
+across all chains, as raw transfers. No swaps, so asset identity and cost basis
+survive; the sale can happen later in B. `scripts/drain.py`
+
+**Phase 2 — liquidate.** Convert a wallet's whole multi-chain portfolio into USDC
+on one destination chain, keeping a gas reserve everywhere. `scripts/liquidate.py`
+
+Read `references/gotchas.md` before the first run of a session. It documents
+failure modes that are silent, expensive, and not inferable from the CLI's output.
+
+## Always do these
+
+1. **Preflight auth.** `scripts/preflight.py --wallet "<name>"`. An invalid API key
+   makes every CLI command hang forever with no error, and expired policies block
+   all writes. Both are ~1 minute to check and hours to debug.
+2. **Run batches detached.** `nohup python3 -u scripts/<x>.py … > run.log 2>&1 &`,
+   then poll the log. A tool-call timeout kills a batch mid-flight while broadcast
+   transactions still land.
+3. **Verify on-chain, not from CLI output.** `scripts/verify.py --address 0x…`.
+   A hung command is indistinguishable from a working one; equal `latest`/`pending`
+   nonces prove nothing was sent.
+4. **Report failures honestly.** Partial success is the normal outcome. Give counts
+   by failure code and name what was left behind and why.
+
+## Workflow
+
+### 0. Inventory
+
+```bash
+scripts/inventory.py --address 0x… --min-value 1
+```
+
+Separates real wallet tokens from DeFi positions, groups by chain, marks
+unreachable chains, and flags broken price feeds. **Its totals — not
+`zerion portfolio` — are the ones to quote.** Portfolio totals routinely include
+4000x-wrong price rows and double-counted DeFi underlyings.
+
+### 1. Drain (optional)
+
+```bash
+scripts/drain.py --from <wallet> --to 0x… --min-value 1 --dry-run   # review
+nohup python3 -u scripts/drain.py --from <wallet> --to 0x… > drain.log 2>&1 &
+```
+
+Sends ERC-20s first and native last on each chain (native pays the gas), shaves
+0.1% off ERC-20 amounts, holds back a per-chain gas reserve, and skips rows that
+cannot succeed: duplicate symbols on one chain (sends resolve by symbol and would
+hit the wrong contract) and blank symbols.
+
+Expect ~80% success. The residue is spam tokens whose symbols collide with real
+holdings — irreducible while `send` has no contract-address argument.
+
+### 2. Liquidate
+
+```bash
+scripts/liquidate.py --wallet "<name>" --plan-only          # review
+nohup python3 -u scripts/liquidate.py --wallet "<name>" > liq.log 2>&1 &
+```
+
+Four stages, `--stages ABCD` to run a subset:
+
+| | Stage | Why here |
+|---|---|---|
+| A | sweep each chain's ERC-20s → that chain's USDC (WETH where no USDC exists) | before native, which pays for it |
+| B | bridge that USDC → destination | |
+| C | bridge each chain's **native** → destination USDC, minus reserve | one hop, half the fees of swap-then-bridge |
+| D | destination chain: sweep ERC-20s, then swap native minus reserve | last, so gas exists throughout |
+
+`--dest` defaults to `ethereum`. Stage C is the one most easily forgotten and
+usually the largest: `consolidate` **silently** drops native rows without
+`--include-native`, so a sweep can look complete while every chain's ETH sits
+untouched.
+
+**Gas is the binding constraint, not the quotes.** Two failure modes follow from
+that, and the scripts now guard both:
+
+- **Stage A reserves gas for the stage-B bridge that must follow it.** Every swap
+  spends native, and stage B then needs one more transaction to bridge the proceeds
+  out. Sweeping a chain until its gas runs out converts sellable tokens into an
+  *unsendable* pile of USDC/WETH. `gas.affordable_swaps()` caps each chain's sweep
+  at what it can fund while still paying for the bridge; surplus rows are deferred
+  lowest-value-first and logged, and a chain that cannot fund even one bridge is
+  skipped up front with a top-up hint. Calibrated on a real run where 44 swaps on
+  `robinhood` ate $12 of ETH (~$0.27 each) and stranded $1,893 of WETH behind them.
+- **The reserve is USD-aware.** A native-unit reserve is worth cents on cheap chains
+  (1 POL ≈ $0.20, 1 S ≈ $0.03), so a chain would pass the old flat "$5 of balance"
+  test, bridge nearly everything away, and be left unable to broadcast anything.
+  `reserve_for(chain, price)` keeps the larger of the native figure and
+  `MIN_RESERVE_USD` ($2.50), and stage C applies its `MIN_BRIDGE_USD` floor to the
+  amount *actually leaving* rather than to the pre-reserve balance.
+
+The cost of both guards is a few dollars of gas retained per chain. That is the
+intended trade: a chain with gas can be retried, a chain without gas cannot.
+
+### 3. Verify and report
+
+```bash
+scripts/verify.py --address 0x…
+scripts/inventory.py --address 0x… --min-value 5     # what's left
+```
+
+Report the on-chain destination balance, then itemize the remainder split into
+**unreachable** (no trading/bridging on that chain), **uneconomic** (fees exceed
+value, or quotes show >50% loss), and **DeFi** (needs protocol withdrawal).
+
+## What this cannot do
+
+- **Withdraw DeFi positions.** The CLI has no withdraw/unstake/redeem/claim
+  command, and receipt tokens (`aArbLINK`, `eETH`, `cETH`, `pufETH`, `sOHM`, `DPI`…)
+  have no swap route — verified, they quote ~$0 or `no_route`. Route the user to
+  the Zerion web app (`zerion wallet sync --wallet <name>`) or each protocol's UI.
+- **Sign for a wallet not in the local vault.** `zerion wallet list` is the whole
+  set. Without the key, nothing moves.
+- **Reach `aurora`, `polygon-zkevm`, `okbchain`, `degen`.** Indexed but not
+  tradeable or bridgeable; needs a manual bridge.
+- **Create an agent token.** Needs a real TTY — the user must run `create-token` in
+  their own terminal. `create-policy` is agent-runnable.
+
+## Decisions worth surfacing before executing
+
+- **Drain-then-liquidate vs liquidate-in-place.** Draining raw preserves cost basis
+  and puts the taxable event in the destination wallet; consolidating first inverts
+  that. If the user has previously chosen a two-phase shape "for accounting
+  reasons", don't quietly collapse it.
+- **The gas reserve.** "Swap all of it" and "leave the wallet able to transact" are
+  in tension. Keep a reserve by default (`scripts/gas.py`), state the amount, and
+  offer to zero it.
+- **The dust floor.** Below ~$2 fees exceed the balance. Say what is being skipped
+  and its total rather than silently dropping it.

--- a/skills/treasury-liquidation/references/gotchas.md
+++ b/skills/treasury-liquidation/references/gotchas.md
@@ -88,6 +88,15 @@ reserve too small to broadcast anything — so any residue there is stranded unt
 manual top-up. Size reserves in USD, and apply the bridge floor to the amount
 actually leaving (balance minus reserve), not to the balance before it.
 
+**The positions indexer lags fresh deposits by minutes.** A bridge reported
+`delivery=delivered` and `eth_getBalance` showed 132 POL on-chain while the
+positions API still returned $0.00 native for that chain — which made a
+gas-affordability check false-skip the whole chain moments after it had been
+deliberately topped up. Cuts the other way too: quantities read from `positions`
+right after a batch of swaps miss the proceeds (a bridge sized from that read
+carried $3 instead of $100). After any top-up or sweep, confirm via RPC before
+acting on an indexer read.
+
 **Trust on-chain balances over everything.** `eth_getBalance` for native,
 `eth_call` + `0x70a08231<padded addr>` for ERC-20. Use
 `https://ethereum-rpc.publicnode.com` (llamarpc 521s, cloudflare-eth errors).

--- a/skills/treasury-liquidation/references/gotchas.md
+++ b/skills/treasury-liquidation/references/gotchas.md
@@ -1,0 +1,213 @@
+# Zerion CLI gotchas
+
+Behaviors learned from real multi-chain liquidations. Each cost real money or hours.
+
+- [Auth](#auth)
+- [Silent filters and wrong numbers](#silent-filters-and-wrong-numbers)
+- [Quotes that lie](#quotes-that-lie)
+- [Sends](#sends)
+- [Bridges](#bridges)
+- [Chain support](#chain-support)
+- [Execution mechanics](#execution-mechanics)
+
+## Auth
+
+**An invalid or revoked API key makes the CLI HANG FOREVER.** No error, no timeout,
+no output — reads included. Diagnosing this from CLI behavior alone is impossible.
+
+`ZERION_API_KEY` in the environment **overrides `~/.zerion/config.json`**, and an
+already-running shell keeps exporting whatever it started with, so editing
+`config.json` and `~/.zshrc` fixes nothing for the current session. Rotating a key
+mid-session breaks everything already running.
+
+Confirm over raw HTTP, which fails fast:
+
+```bash
+curl -sL -H "Authorization: Basic $(printf '%s:' "$KEY" | base64)" \
+  https://api.zerion.io/v1/chains/ -o /dev/null -w '%{http_code}\n'
+```
+
+200 from curl while the CLI hangs = stale env key. Fix by prefixing every call:
+`ZERION_API_KEY=<new> zerion …`. Shell state does not persist between agent tool
+calls, so prefix *each* one. (API paths need no trailing slash — a trailing `/`
+returns a 301 that `curl` won't follow without `-L`.)
+
+**`agent create-token` requires a real TTY.** It fails with "Passphrase must be
+entered in an interactive terminal" from an agent shell *and* from Claude Code's
+`!` prefix. Only the user, in their own terminal window, can create one.
+`create-policy` and `use-token` need no passphrase and are agent-runnable.
+
+**Policies expire and block writes before broadcast** with
+`policy denied: policy expired at …`. Costs nothing but blocks everything. Check
+expiry before planning a long run. `--deny-transfers` blocks only *native*
+transfers, not ERC-20 sends.
+
+## Silent filters and wrong numbers
+
+**`consolidate` excludes the native gas token by default and says nothing about
+it.** No warning, no skipped row in the output — the balance simply stays put. A
+sweep can report "233 swaps succeeded" while every chain's ETH is untouched. Pass
+`--include-native` (with `--gas-reserve`), or handle native separately. This is
+the single easiest way to silently leave five figures behind.
+
+Stablecoins are likewise excluded unless `--include-stables` is passed (non-TTY
+contexts default to excluding, without prompting).
+
+**`zerion positions` re-lists DeFi underlyings as if they were wallet tokens.** An
+Aave deposit shows both `aArbLINK` (the receipt token, genuinely held) *and* `LINK`
+(the underlying, not held) at byte-identical quantities. Index Coop baskets surface
+their constituents the same way. Sweeping those phantom rows makes `transferFrom`
+revert on-chain — more than half the swaps in one Ethereum run failed this way.
+
+The raw API carries `position_type`, so the distinction is unambiguous:
+
+```
+GET /v1/wallets/<addr>/positions?page[size]=100   →  attributes.position_type
+```
+
+Filter to `wallet` client-side. (A `filter[position_types]=wallet` query param
+returns zero rows — don't use it.)
+
+**Price feeds can be catastrophically wrong.** One run priced a staked-governance
+token at roughly 4000x its real value — enough that a single row dominated the
+reported portfolio total. Never quote a portfolio total without sanity-checking any
+row above ~25% of the book.
+
+**A sweep that exhausts a chain's gas strands its own proceeds.** `consolidate`
+happily swaps until the native balance is gone, and the bridge that has to follow
+then fails `not_enough_base_asset_balance`. The tokens have been converted but
+cannot leave — strictly worse than not sweeping, because the original assets are
+gone too. Seen twice: 44 swaps on `robinhood` spent $12 of ETH (~$0.27 each) and
+left $1,893 of WETH unbridgeable; a `polygon` sweep attempted 3 swaps holding
+$0.00 of POL. Budget gas for `swaps + 1 bridge` *before* sweeping, not after.
+
+**A native-unit gas reserve is worth cents on cheap chains.** 1 POL ≈ $0.20,
+1 XDAI ≈ $1.00, 1 S ≈ $0.03. Combined with a flat "skip if balance < $5" test, a
+chain passes the check, bridges nearly everything home, and is left holding a
+reserve too small to broadcast anything — so any residue there is stranded until a
+manual top-up. Size reserves in USD, and apply the bridge floor to the amount
+actually leaving (balance minus reserve), not to the balance before it.
+
+**Trust on-chain balances over everything.** `eth_getBalance` for native,
+`eth_call` + `0x70a08231<padded addr>` for ERC-20. Use
+`https://ethereum-rpc.publicnode.com` (llamarpc 521s, cloudflare-eth errors).
+
+## Quotes that lie
+
+**`consolidate` has no max-GAIN filter.** Broken or illiquid tokens return absurd
+quotes — multiples of 2,716x and 146,000x the input have both been seen. They pass the
+max-LOSS check as `ready`. On-chain `outputMin` makes them revert, so no funds are
+lost, but gas is. **Pre-filter anything quoting above ~2x expected value.**
+
+Absurd quotes are **not stable between runs** — `X` was 146,000x one session and
+priced normally the next, while `ACH` went the other way. Recompute the exclusion
+list from a fresh dry-run every time; never reuse a saved list.
+
+**DeFi receipt tokens have no swap route.** `aArbLINK`, `eETH`, `cETH`, `sETH2`,
+`aSTETH`, `pufETH`, `ETHx`, `ankrETH`, `yvBOOST`, `DPI`, `sOHM` all quote ~$0 output
+or `no_route`. Their value is real but only a **protocol withdrawal** (Zerion web
+app, or the protocol's own UI) frees it. Exclude them from sweeps.
+
+**`--execute` re-plans and re-quotes.** The plan just read is not what gets
+broadcast; rows that were `ready` can vanish (`"No ready rows to execute."`) or
+newly appear. Re-check afterwards rather than trusting the earlier plan.
+
+**`loss_pct` is the expected loss, not the floor.** Realized output is bounded by
+`outputMin`, roughly `--slippage` below expected. A row at 4.9% loss with 2%
+slippage can land at ~6.9%.
+
+Default `--max-loss` is 5%, which blocks genuinely-worthwhile rows on illiquid
+chains. Raising to ~12% can recover meaningful value; check the ratios first.
+
+## Sends
+
+**No "send max".** `send` needs an explicit amount, and sending the indexer's full
+quantity fails `insufficient_balance` (have ≈ need) because the indexer rounds up
+past real wei. **Shave 0.1% (`qty * 0.999`).**
+
+**Sends resolve BY SYMBOL, and positions carry no contract address.** Two tokens
+sharing a symbol on one chain both resolve to the wrong contract (`have 0`). Skip
+any symbol appearing more than once per chain — it is unrecoverable via `send`.
+
+**Blank symbols produce `zerion send "" …` → `missing_args`.** Filter empty and
+whitespace-only symbols when generating commands.
+
+**Send native LAST on each chain.** It pays the gas; sending it first strands every
+remaining ERC-20 on that chain.
+
+The old "intrinsic gas too low" native-send bug (hardcoded 21000 gas) appears
+**fixed as of v1.8.0** — robinhood, base, megaeth, and Ethereum native sends all
+succeeded where they previously failed.
+
+## Bridges
+
+**Bare `zerion bridge` AUTO-EXECUTES when only one provider offers a route.** It
+only lists-and-exits on multi-offer pairs. There is no `--dry-run` and no safe
+read-only probe — treat *any* bridge invocation as a commitment to move funds. To
+test reachability without signing, run `zerion consolidate <chain> <token>` (always
+dry-run by default) and read the error code.
+
+`--cheapest` executes the highest-output route deterministically; prefer it over
+the bare form so behavior doesn't depend on how many providers happen to quote.
+
+**`delivery=timeout` usually still lands.** The source transaction succeeded and
+the poll window simply expired. Confirm by checking the source chain drained rather
+than re-sending — a blind retry double-bridges.
+
+**Transient failures are common and usually succeed on retry:**
+`broadcast_failed: Transaction broadcast failed`, RPC errors, `HTTP request failed`.
+Build in one automatic retry. One AVAX bridge failed twice and worked on the third.
+
+**Bridge native straight to destination USDC** (`bridge <chain> ETH <amt> ethereum
+USDC`) rather than swapping to USDC locally then bridging — one hop, half the fees.
+
+Below roughly $2–5 the bridge fee consumes the whole transfer; a sub-$20 position
+can lose ~30% of its value in fees.
+
+## Chain support
+
+Support is three independent capabilities — indexed, tradeable, bridgeable — and a
+chain can have any subset. The authoritative probe is a `consolidate` dry-run:
+
+| Signal | Meaning |
+|---|---|
+| `chain_capability_missing` | no trading (error names the supported chains) |
+| `target_token_not_found` | trades, but no USDC implementation — target `WETH` instead |
+| valid plan returned | tradeable |
+
+Bridging is separate and has its own `chain_capability_missing`.
+
+Observed (re-verify; the CLI's chain list grows):
+
+- **No trading or bridging:** `aurora`, `polygon-zkevm`, `okbchain`, `degen`.
+  Value here needs a manual bridge through the chain's own UI.
+- **No USDC implementation:** `robinhood`, `blast`, `megaeth` → sweep to `WETH`,
+  then bridge WETH → destination USDC.
+- **`celo` is effectively broken:** every send failed `broadcast_failed`, and
+  bridges failed with "Base asset balance is not enough to cover network fee"
+  despite a funded CELO balance on that chain.
+- **`gnosis` vs `xdai`:** analytics says `xdai`; the send engine rejects `gnosis`.
+
+## Execution mechanics
+
+**Run long batches detached** (`nohup … &`). A sweep is hundreds of sequential
+confirmations; a wrapper timeout kills it mid-batch while already-broadcast
+transactions still land, leaving state ambiguous.
+
+**Never infer success from process liveness.** A hung command looks exactly like a
+working one. Check the output, then check the chain.
+
+**zsh does not word-split unquoted `$var`.** `for a in "base USDC 5 ethereum USDC";
+do zerion bridge $a; done` passes one argument and fails `missing_args`. Use `"$@"`,
+`${=a}`, or emit one full command per line.
+
+**Parse output with `raw_decode`, not `json.loads`.** Commands print human lines
+("Broadcasting…", "Tx hash: …") before the JSON, sometimes with trailing text:
+
+```python
+i = out.find("{")
+data = json.JSONDecoder().raw_decode(out[i:])[0]
+```
+
+**`consolidate --execute` is sequential** regardless of `--concurrency`, which only
+affects plan-phase quote fetching (paid keys → 5, `zk_dev_` keys → 1).

--- a/skills/treasury-liquidation/scripts/drain.py
+++ b/skills/treasury-liquidation/scripts/drain.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""PHASE 1 -- send every token above a floor from one wallet to another, all chains.
+
+Raw transfers only: no swaps, so asset identity (and its cost basis) is preserved.
+Use this when the sale should happen in the destination wallet, not the source.
+
+Ordering is load-bearing: on each chain the native token pays for gas, so it is
+sent LAST. Sending it first strands every remaining ERC-20 on that chain.
+
+Usage:
+    drain.py --from <source-wallet> --to 0x<destination-address> [--min-value 1] [--dry-run]
+
+Run detached (nohup) -- a full drain is hundreds of sequential confirmations and
+must not sit inside a tool-call timeout.
+"""
+import argparse, json, os, subprocess, sys, time
+from collections import defaultdict
+from decimal import Decimal
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from inventory import fetch, norm, key  # noqa: E402
+from gas import reserve_for  # noqa: E402
+
+
+def run(args, timeout=600):
+    env = dict(os.environ, ZERION_API_KEY=key())
+    try:
+        p = subprocess.run(args, capture_output=True, text=True, timeout=timeout, env=env)
+        out = p.stdout + p.stderr
+    except subprocess.TimeoutExpired:
+        return {"error": {"code": "local_timeout"}}
+    i = out.find("{")
+    if i < 0:
+        return {"error": {"code": "no_json", "message": out[:160]}}
+    try:
+        return json.JSONDecoder().raw_decode(out[i:])[0]
+    except Exception:
+        return {"error": {"code": "unparseable", "message": out[:160]}}
+
+
+def build(rows, min_value):
+    """Return (sends, skipped). sends are ordered ERC-20s-then-native, per chain."""
+    by = defaultdict(list)
+    for p in rows:
+        if p["type"] == "wallet" and p["value"] >= min_value:
+            by[p["chain"]].append(p)
+
+    sends, skipped = [], []
+    for ch, items in sorted(by.items(), key=lambda kv: -sum(x["value"] for x in kv[1])):
+        seen = defaultdict(int)
+        for p in items:
+            seen[p["symbol"]] += 1
+        erc = [p for p in items if not p["native"]]
+        nat = [p for p in items if p["native"]]
+        for p in erc + nat:                      # native LAST: it pays the gas
+            sym = p["symbol"]
+            if not sym or not sym.strip() or sym == "?":
+                skipped.append((p, "blank symbol"))   # `zerion send ""` -> missing_args
+                continue
+            if seen[sym] > 1:
+                # `send` resolves BY SYMBOL; duplicates hit the wrong contract ("have 0")
+                skipped.append((p, f"symbol x{seen[sym]} on {ch}"))
+                continue
+            q = Decimal(str(p["qty"]))
+            if p["native"]:
+                # Price-aware: a native-unit reserve is worth cents on cheap chains,
+                # leaving the source wallet unable to broadcast a retry.
+                amt = q - Decimal(reserve_for(ch, p.get("price")))
+                if amt <= 0:
+                    skipped.append((p, "below gas reserve"))
+                    continue
+            else:
+                amt = q * Decimal("0.999")   # indexer rounds UP past real wei
+            if amt <= 0:
+                continue
+            sends.append((ch, sym, format(amt.normalize(), "f"), p["value"], p["native"]))
+    return sends, skipped
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--from", dest="src", required=True, help="source wallet name")
+    ap.add_argument("--to", required=True, help="destination 0x address")
+    ap.add_argument("--min-value", type=float, default=1.0)
+    ap.add_argument("--dry-run", action="store_true")
+    a = ap.parse_args()
+
+    wl = run(["zerion", "wallet", "list"])
+    addr = next((w["evmAddress"] for w in wl.get("wallets", []) if w["name"] == a.src), None)
+    if not addr:
+        print(f"source wallet '{a.src}' not in vault"); return 1
+
+    sends, skipped = build(norm(fetch(addr, key())), a.min_value)
+    print(f"PLAN: {len(sends)} sends, ${sum(s[3] for s in sends):,.2f}")
+    print(f"SKIP: {len(skipped)} rows, ${sum(p['value'] for p, _ in skipped):,.2f}")
+    for p, why in sorted(skipped, key=lambda x: -x[0]["value"])[:10]:
+        print(f"   {p['value']:8.2f} {p['symbol']:12s} {p['chain']:16s} {why}")
+    if a.dry_run:
+        for ch, sym, amt, v, nat in sends[:40]:
+            print(f"   {v:9.2f} {sym:12s} {ch:16s} {amt}{'  [native, last]' if nat else ''}")
+        return 0
+
+    ok, fail = 0, defaultdict(list)
+    for i, (ch, sym, amt, v, nat) in enumerate(sends, 1):
+        print(f"[{i}/{len(sends)}] {ch} {sym} ${v:.2f}", flush=True)
+        d = run(["zerion", "send", sym, amt, "--to", a.to, "--chain", ch, "--wallet", a.src])
+        if d.get("error"):
+            code = d["error"].get("code", "?")
+            fail[code].append((ch, sym, v))
+            print(f"    FAIL {code}: {str(d['error'].get('message'))[:90]}", flush=True)
+        elif (d.get("tx") or {}).get("status") == "success":
+            ok += 1
+            print(f"    ok {d['tx']['hash'][:14]}", flush=True)
+        else:
+            fail[str((d.get("tx") or {}).get("status"))].append((ch, sym, v))
+            print(f"    FAIL tx={(d.get('tx') or {}).get('status')}", flush=True)
+
+    print(f"\n=== DRAIN: {ok}/{len(sends)} ok ===")
+    for code, rows in sorted(fail.items(), key=lambda x: -len(x[1])):
+        print(f"  {len(rows):4d}  {code}  (${sum(r[2] for r in rows):,.2f})")
+    print("DRAINDONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/treasury-liquidation/scripts/gas.py
+++ b/skills/treasury-liquidation/scripts/gas.py
@@ -1,0 +1,107 @@
+"""Per-chain native-token reserves and gas affordability.
+
+Two things have to be true of a reserve, and a single native-unit figure only
+guarantees the first:
+
+  1. It must not strand real value -- so it cannot be large.
+  2. It must actually pay for a few more transactions -- so it cannot be worth
+     cents.
+
+Native-unit reserves alone fail (2) on cheap chains. A reserve of 1 POL or 1 XDAI
+is worth roughly $0.20; once a sweep has bridged the rest of the balance away that
+chain cannot broadcast anything, and whatever failed to sell there is stranded
+until someone tops it up by hand. That is how value was lost in two real runs.
+
+So the reserve is the LARGER of the per-chain native figure and whatever amount is
+worth MIN_RESERVE_USD. Pass `price` (USD per native unit) to get that behaviour;
+without it you get the bare native figure and the previous semantics.
+"""
+from decimal import Decimal
+
+# Enough to cover several more transactions on that chain, not so much that real
+# value is stranded. Sized from observed gas costs during real sweeps; the L2
+# figures are deliberately generous because a chain left with zero gas becomes
+# unusable and its remaining tokens unrecoverable without a manual top-up.
+RESERVE = {
+    # Ethereum mainnet: gas is expensive, keep the most.
+    "ethereum": "0.005",
+    # ETH-denominated L2s.
+    "base": "0.0008", "arbitrum": "0.0008", "optimism": "0.0008", "scroll": "0.0008",
+    "linea": "0.0008", "zora": "0.0008", "blast": "0.0008", "ink": "0.0008",
+    "soneium": "0.0008", "unichain": "0.0008", "world": "0.0008", "katana": "0.0008",
+    "megaeth": "0.0008", "zksync-era": "0.0015", "abstract": "0.0015",
+    "robinhood": "0.0015",
+    # Own-gas-token chains.
+    "binance-smart-chain": "0.004", "avalanche": "0.03", "polygon": "1",
+    "xdai": "1", "celo": "0.5", "mantle": "2", "ape": "2", "monad": "5",
+    "hyperevm": "0.05", "sonic": "1", "berachain": "0.1", "plasma": "1",
+    "lens": "0.3", "gravity-alpha": "1",
+}
+DEFAULT = "0.002"
+
+# A reserve worth less than this cannot fund a retry, so the chain becomes a
+# one-way trip. Cheap-gas chains need this floor; Ethereum's native figure
+# already exceeds it.
+MIN_RESERVE_USD = 2.50
+
+# Rough per-transaction gas costs in USD, used to decide whether a chain can
+# afford a planned batch. Deliberately conservative: overestimating leaves a
+# little dust behind, underestimating strands a whole chain's proceeds.
+#
+# Calibrated against a real run: 44 consolidate swaps on `robinhood` consumed
+# ~$12.00 of ETH, i.e. ~$0.27 each. An earlier $0.12 guess would have permitted
+# 96 swaps and reproduced exactly the failure this cap exists to prevent, so the
+# default is rounded UP from the observed figure rather than down.
+SWAP_GAS_USD = {"ethereum": 3.00}
+BRIDGE_GAS_USD = {"ethereum": 4.00}
+DEFAULT_SWAP_GAS_USD = 0.30
+DEFAULT_BRIDGE_GAS_USD = 0.40
+
+
+def reserve_for(chain, price=None):
+    """Native units to keep on `chain`.
+
+    `price` is USD per native unit. When given, the reserve is raised so that it is
+    worth at least MIN_RESERVE_USD -- otherwise cheap chains keep a reserve worth
+    cents and end up unable to transact at all.
+    """
+    base = Decimal(RESERVE.get(chain, DEFAULT))
+    if price:
+        try:
+            p = Decimal(str(price))
+        except Exception:
+            return str(base)
+        if p > 0:
+            needed = Decimal(str(MIN_RESERVE_USD)) / p
+            if needed > base:
+                return format(needed.normalize(), "f")
+    return str(base)
+
+
+def reserve_usd(chain, price=None):
+    """What the reserve is worth, for logging and floor comparisons."""
+    if not price:
+        return None
+    return float(Decimal(reserve_for(chain, price)) * Decimal(str(price)))
+
+
+def swap_gas_usd(chain):
+    return SWAP_GAS_USD.get(chain, DEFAULT_SWAP_GAS_USD)
+
+
+def bridge_gas_usd(chain):
+    return BRIDGE_GAS_USD.get(chain, DEFAULT_BRIDGE_GAS_USD)
+
+
+def affordable_swaps(chain, native_usd):
+    """How many swaps this chain's gas can fund while still leaving enough for the
+    bridge that has to follow them.
+
+    Sweeping a chain down to its last cent of gas is self-defeating: the proceeds
+    then cannot be bridged out, so the sweep has only converted tokens into a
+    different stranded token. Returns 0 when the chain cannot even fund a bridge.
+    """
+    budget = (native_usd or 0) - bridge_gas_usd(chain)
+    if budget <= 0:
+        return 0
+    return int(budget // swap_gas_usd(chain))

--- a/skills/treasury-liquidation/scripts/inventory.py
+++ b/skills/treasury-liquidation/scripts/inventory.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Accurate multi-chain inventory. Separates real wallet tokens from DeFi noise.
+
+Why not just `zerion positions`: that view re-lists DeFi *underlyings* (an Aave
+deposit's LINK, an Index Coop basket's ENA) as if they were wallet tokens. Sweeping
+them makes `consolidate` try to sell tokens the wallet doesn't hold, and the swaps
+revert on-chain -- burning gas. The raw API carries `position_type`, so wallet vs
+DeFi is unambiguous.
+
+Also flags broken price feeds: a single bad row (a token quoted thousands of times
+its real value) can inflate the reported total beyond recognition.
+
+Usage:
+    inventory.py --address 0x... [--min-value 1] [--json out.json]
+"""
+import argparse, json, os, sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from netutil import get_json  # noqa: E402
+from collections import defaultdict
+
+API = "https://api.zerion.io/v1"
+# Chains Zerion indexes but cannot trade or bridge -- value here is unreachable.
+NO_TRADE = {"aurora", "polygon-zkevm", "okbchain", "degen", "somnia"}
+# Trade-capable chains with no USDC implementation: sweep to WETH, then bridge.
+NO_USDC = {"robinhood", "blast", "megaeth"}
+
+
+def key():
+    k = os.environ.get("ZERION_API_KEY")
+    if k:
+        return k
+    p = os.path.expanduser("~/.zerion/config.json")
+    if os.path.exists(p):
+        return json.load(open(p)).get("apiKey")
+    return None
+
+
+def fetch(addr, k):
+    """Page through positions. Returns raw JSON:API rows."""
+    rows, url = [], f"{API}/wallets/{addr}/positions?page%5Bsize%5D=100"
+    while url:
+        d = get_json(url, api_key=k)
+        rows += d.get("data", [])
+        url = (d.get("links") or {}).get("next")
+    return rows
+
+
+def norm(rows):
+    out = []
+    for p in rows:
+        a = p["attributes"]
+        fi = a.get("fungible_info") or {}
+        ch = ((p.get("relationships") or {}).get("chain") or {}).get("data", {}).get("id")
+        impls = [i for i in fi.get("implementations", []) if i.get("chain_id") == ch]
+        out.append({
+            "chain": ch,
+            "symbol": (fi.get("symbol") or "?"),
+            "name": fi.get("name") or "",
+            "type": a.get("position_type") or "?",
+            "value": float(a.get("value") or 0),
+            "qty": float((a.get("quantity") or {}).get("float") or 0),
+            "price": float(a.get("price") or 0),
+            "address": impls[0].get("address") if impls else None,
+            "native": bool(impls) and impls[0].get("address") is None,
+        })
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--address", required=True)
+    ap.add_argument("--min-value", type=float, default=1.0)
+    ap.add_argument("--json")
+    a = ap.parse_args()
+
+    k = key()
+    if not k:
+        print("no API key; set ZERION_API_KEY", file=sys.stderr)
+        return 1
+    pos = norm(fetch(a.address, k))
+
+    wallet = [p for p in pos if p["type"] == "wallet"]
+    defi = [p for p in pos if p["type"] != "wallet"]
+
+    # Price-feed sanity: a token worth >25% of the book on its own is usually a bad feed.
+    total = sum(p["value"] for p in wallet)
+    suspect = [p for p in wallet if total and p["value"] / total > 0.25 and p["value"] > 10000]
+
+    live = [p for p in wallet if p["value"] >= a.min_value and p not in suspect]
+    print(f"WALLET positions >= ${a.min_value:g}: {len(live)}  "
+          f"${sum(p['value'] for p in live):,.2f}")
+    print(f"DeFi positions: {len(defi)}  ${sum(p['value'] for p in defi):,.2f} "
+          f"(NOT sweepable -- receipt tokens have no swap route)")
+    if suspect:
+        print("\n!! SUSPECT PRICE FEEDS (excluded from totals -- verify before trusting):")
+        for p in suspect:
+            print(f"   {p['symbol']:10s} {p['chain']:12s} qty={p['qty']:.6f} "
+                  f"@ ${p['price']:,.2f} = ${p['value']:,.2f}")
+
+    by = defaultdict(list)
+    for p in live:
+        by[p["chain"]].append(p)
+
+    print(f"\n{'chain':22s} {'total':>10s} {'n':>4s}  {'route':16s} {'native':>9s}")
+    reach = unreach = 0.0
+    for ch, ps in sorted(by.items(), key=lambda kv: -sum(x["value"] for x in kv[1])):
+        t = sum(x["value"] for x in ps)
+        nat = sum(x["value"] for x in ps if x["native"])
+        if ch in NO_TRADE:
+            route, unreach = "UNREACHABLE", unreach + t
+        else:
+            route = "-> WETH" if ch in NO_USDC else "-> USDC"
+            reach += t
+        print(f"{ch:22s} {t:10,.2f} {len(ps):4d}  {route:16s} {nat:9,.2f}")
+
+    print(f"\nreachable   ${reach:,.2f}")
+    print(f"unreachable ${unreach:,.2f}  (no trading or bridging on Zerion)")
+    print(f"defi        ${sum(p['value'] for p in defi):,.2f}  (needs protocol withdrawal)")
+
+    if a.json:
+        json.dump({"wallet": live, "defi": defi, "suspect": suspect},
+                  open(a.json, "w"), indent=2)
+        print(f"\nwrote {a.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/treasury-liquidation/scripts/liquidate.py
+++ b/skills/treasury-liquidation/scripts/liquidate.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""PHASE 2 -- convert everything in one wallet into USDC on a single chain.
+
+Four stages, in this order for a reason:
+  A  sweep each chain's ERC-20s into that chain's USDC (WETH where no USDC exists)
+  B  bridge that USDC to the destination chain
+  C  bridge each chain's NATIVE token straight to destination USDC, minus a gas
+     reserve -- one hop, half the fees of swap-then-bridge
+  D  on the destination chain: sweep ERC-20s, then swap native minus reserve
+
+Native goes last everywhere because it pays for the transactions before it.
+
+Usage:
+    liquidate.py --wallet "<wallet-name>" [--dest ethereum] [--min-value 1]
+    liquidate.py --wallet "<wallet-name>" --plan-only
+    liquidate.py --wallet "<wallet-name>" --stages CD
+
+Run detached (nohup). A full run is hundreds of sequential confirmations.
+"""
+import argparse, json, os, subprocess, sys, time
+from decimal import Decimal
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from inventory import fetch, norm, key, NO_TRADE, NO_USDC  # noqa: E402
+from gas import (  # noqa: E402
+    reserve_for, reserve_usd, affordable_swaps, bridge_gas_usd, MIN_RESERVE_USD,
+)
+
+# Receipt tokens for DeFi positions. They quote at ~0 output or no_route, and
+# swapping them reverts on-chain. Only a protocol withdrawal frees this value.
+DEFI_RECEIPTS = {
+    "AARBLINK", "ALINK", "AUSDT", "ASTETH", "AETH", "AETHWBTC", "AETHWETH", "STKAAVE",
+    "CETH", "EETH", "SETH2", "RETH2", "PUFETH", "ETHX", "ANKRETH", "RSETH", "RSWETH",
+    "SWETH", "STETH", "OETH", "YVBOOST", "YVECRV-DAO", "SOHM", "XSUSHI", "UNI-V2",
+    "3CRV", "SBTCCRV", "DPI", "MVI", "BTC2X-FLI", "ETH2X-FLI",
+}
+MAX_GAIN = 2.0   # quotes above this multiple are the known absurd-quote bug
+# Below this, a bridge's fee consumes the transfer. Applied to the amount actually
+# leaving the chain (balance minus gas reserve), never to the raw balance.
+MIN_BRIDGE_USD = 5.0
+
+
+def run(args, timeout=1800):
+    env = dict(os.environ, ZERION_API_KEY=key())
+    try:
+        p = subprocess.run(args, capture_output=True, text=True, timeout=timeout, env=env)
+        out = p.stdout + p.stderr
+    except subprocess.TimeoutExpired:
+        return {"error": {"code": "local_timeout"}}
+    i = out.find("{")
+    if i < 0:
+        return {"error": {"code": "no_json", "message": out[:200]}}
+    try:
+        return json.JSONDecoder().raw_decode(out[i:])[0]
+    except Exception:
+        return {"error": {"code": "unparseable", "message": out[:200]}}
+
+
+def log(m):
+    print(m, flush=True)
+
+
+def chains_with_value(wallet_addr, min_value, dest):
+    rows = [p for p in norm(fetch(wallet_addr, key()))
+            if p["type"] == "wallet" and p["value"] >= min_value]
+    out = {}
+    for p in rows:
+        out.setdefault(p["chain"], []).append(p)
+    return {c: v for c, v in out.items() if c not in NO_TRADE}
+
+
+def target_for(chain):
+    return "WETH" if chain in NO_USDC else "USDC"
+
+
+def native_of(chain, rows):
+    """The chain's native row, which carries both its balance and its USD price."""
+    for p in rows:
+        if p["chain"] == chain and p["native"] and p["type"] == "wallet":
+            return p
+    return None
+
+
+def stage_a(wallet, chains, dest, min_value):
+    """Sweep ERC-20s per chain. Native excluded here -- stage C handles it.
+
+    Gas is the binding constraint, not the quotes. Each swap spends the chain's
+    native token, and stage B then needs one more transaction to bridge the
+    proceeds out. Sweeping until the gas runs out therefore converts sellable
+    tokens into an unsendable pile of USDC/WETH -- observed twice, once stranding
+    $1.9k of WETH on a chain with $0 of gas left.
+
+    So the sweep is capped at what the chain can afford while still funding the
+    follow-on bridge.
+    """
+    log("\n===== STAGE A: per-chain ERC-20 sweep =====")
+    for ch in [c for c in chains if c != dest]:
+        tgt = target_for(ch)
+        nat = native_of(ch, chains.get(ch, []))
+        native_usd = (nat or {}).get("value") or 0.0
+        budget = affordable_swaps(ch, native_usd)
+        if budget < 1:
+            log(f"{ch}: SKIPPED -- gas ${native_usd:,.2f} cannot fund a sweep plus "
+                f"the bridge that must follow (needs > ${bridge_gas_usd(ch):.2f}). "
+                f"Top up native on {ch} to recover this chain.")
+            continue
+
+        plan = run(["zerion", "consolidate", ch, tgt, "--wallet", wallet,
+                    "--include-stables", "--min-value", str(min_value)])
+        if plan.get("error"):
+            log(f"{ch}: plan failed {plan['error'].get('code')}")
+            continue
+        excl = set()
+        ready = []
+        for r in plan.get("rows", []):
+            if r.get("status") != "ready":
+                continue
+            v, o = r.get("value_usd") or 0, r.get("expected_output_usd") or 0
+            if r["symbol"].upper() in DEFI_RECEIPTS or (v > 0 and o / v > MAX_GAIN):
+                excl.add(r["symbol"])
+            else:
+                ready.append(r)
+        if not ready:
+            log(f"{ch}: nothing sweepable")
+            continue
+
+        # Not enough gas for every row: keep the most valuable ones and raise
+        # --min-value to drop the rest, rather than sweeping until gas runs out.
+        eff_min = min_value
+        dropped = 0
+        if len(ready) > budget:
+            ready.sort(key=lambda r: -(r.get("value_usd") or 0))
+            keep, cut = ready[:budget], ready[budget:]
+            dropped = len(cut)
+            eff_min = max(min_value, (keep[-1].get("value_usd") or min_value))
+            log(f"{ch}: gas ${native_usd:,.2f} funds ~{budget} of {len(ready)} rows; "
+                f"sweeping the top {len(keep)} (>= ${eff_min:,.2f}), deferring "
+                f"{dropped} worth ${sum((r.get('value_usd') or 0) for r in cut):,.2f} "
+                f"so the bridge stays fundable")
+            ready = keep
+
+        cmd = ["zerion", "consolidate", ch, tgt, "--wallet", wallet,
+               "--include-stables", "--min-value", str(eff_min)]
+        if excl:
+            cmd += ["--exclude", ",".join(sorted(excl))]
+        cmd.append("--execute")
+        good = len(ready)
+        log(f"{ch}: sweeping {good} rows -> {tgt} (excluding {len(excl)})")
+        d = run(cmd)
+        s = d.get("summary") or {}
+        log(f"   {s.get('succeeded', '?')} ok, {s.get('failed', '?')} failed")
+
+
+def bridge(chain, sym, amount, dest, wallet, label):
+    """--cheapest ALWAYS executes. Bare `bridge` auto-executes on single-offer too,
+    so there is no safe read-only probe; treat any bridge call as a commitment."""
+    for attempt in (1, 2):
+        d = run(["zerion", "bridge", chain, sym, amount, dest, "USDC",
+                 "--wallet", wallet, "--timeout", "300", "--cheapest"])
+        if d.get("error"):
+            log(f"   {label} attempt {attempt}: ERROR {d['error'].get('code')}")
+            time.sleep(8)
+            continue
+        tx = (d.get("tx") or {}).get("status")
+        bd = d.get("bridgeDelivery") or {}
+        log(f"   {label}: tx={tx} delivery={bd.get('status')} received={bd.get('received')}")
+        if tx == "success":
+            # delivery=timeout still usually lands; confirm later by checking the source drained
+            return Decimal(str(bd.get("received") or 0))
+        time.sleep(8)
+    return None
+
+
+def stage_b(wallet, addr, dest, min_value):
+    log("\n===== STAGE B: bridge stablecoin/WETH balances home =====")
+    got = Decimal(0)
+    for p in norm(fetch(addr, key())):
+        ch = p["chain"]
+        if p["type"] != "wallet" or ch == dest or ch in NO_TRADE:
+            continue
+        want = target_for(ch)
+        if p["symbol"] != want or p["value"] < 2:
+            continue
+        amt = format((Decimal(str(p["qty"])) * Decimal("0.999")).normalize(), "f")
+        r = bridge(ch, want, amt, dest, wallet, f"{ch} {want} ${p['value']:.2f}")
+        if r:
+            got += r
+    log(f"stage B delivered ~{got:.2f} USDC")
+
+
+def stage_c(wallet, addr, dest, min_value):
+    """Native -> destination USDC directly. THE step most easily forgotten:
+    `consolidate` silently drops the native row unless --include-native is set.
+
+    The floor is applied to what would actually be bridged (balance minus the
+    reserve), not to the whole balance. A flat $5-on-the-balance test combined with
+    a native-unit reserve used to bridge away nearly everything on cheap chains and
+    leave a reserve worth cents -- passing the test while making the chain unusable.
+    """
+    log("\n===== STAGE C: bridge native gas tokens home =====")
+    got = Decimal(0)
+    for p in norm(fetch(addr, key())):
+        ch = p["chain"]
+        if p["type"] != "wallet" or not p["native"] or ch == dest or ch in NO_TRADE:
+            continue
+        price = p.get("price") or 0
+        amt = Decimal(str(p["qty"])) - Decimal(reserve_for(ch, price))
+        if amt <= 0:
+            kept = reserve_usd(ch, price)
+            log(f"   {ch} {p['symbol']} ${p['value']:.2f}: at or below reserve"
+                f"{f' (~${kept:,.2f} kept)' if kept else ''}, skipped")
+            continue
+        # Below this, the bridge fee eats the transfer -- judge the amount actually
+        # leaving, not the balance before the reserve is taken out.
+        send_usd = float(amt) * price if price else p["value"]
+        if send_usd < MIN_BRIDGE_USD:
+            log(f"   {ch} {p['symbol']}: only ${send_usd:,.2f} above reserve "
+                f"(< ${MIN_BRIDGE_USD:.2f} floor), leaving it as gas")
+            continue
+        r = bridge(ch, p["symbol"], format(amt.normalize(), "f"), dest, wallet,
+                   f"{ch} {p['symbol']} ${p['value']:.2f}")
+        if r:
+            got += r
+    log(f"stage C delivered ~{got:.2f} USDC")
+
+
+def stage_d(wallet, dest, min_value):
+    log(f"\n===== STAGE D: {dest} local sweep + native swap =====")
+    plan = run(["zerion", "consolidate", dest, "USDC", "--wallet", wallet,
+                "--include-stables", "--min-value", str(min_value)])
+    excl = set()
+    for r in plan.get("rows", []):
+        if r.get("status") != "ready":
+            continue
+        v, o = r.get("value_usd") or 0, r.get("expected_output_usd") or 0
+        if r["symbol"].upper() in DEFI_RECEIPTS or (v > 0 and o / v > MAX_GAIN):
+            excl.add(r["symbol"])
+    cmd = ["zerion", "consolidate", dest, "USDC", "--wallet", wallet,
+           "--include-stables", "--min-value", str(min_value)]
+    if excl:
+        cmd += ["--exclude", ",".join(sorted(excl))]
+    cmd.append("--execute")
+    d = run(cmd)
+    s = d.get("summary") or {}
+    log(f"   sweep: {s.get('succeeded', '?')} ok, {s.get('failed', '?')} failed")
+
+    # Native last, and never all of it.
+    wl = run(["zerion", "wallet", "list"])
+    addr = next((w["evmAddress"] for w in wl.get("wallets", []) if w["name"] == wallet), None)
+    for p in norm(fetch(addr, key())):
+        if p["chain"] == dest and p["native"] and p["type"] == "wallet":
+            price = p.get("price") or 0
+            keep = reserve_for(dest, price)
+            amt = Decimal(str(p["qty"])) - Decimal(keep)
+            if amt <= 0:
+                kept = reserve_usd(dest, price)
+                log(f"   native at or below reserve"
+                    f"{f' (~${kept:,.2f} kept for gas)' if kept else ''}, nothing to swap")
+                break
+            log(f"   swapping {amt} {p['symbol']} -> USDC (reserve {keep} kept)")
+            r = run(["zerion", "swap", dest, format(amt.normalize(), "f"),
+                     p["symbol"], "USDC", "--wallet", wallet,
+                     "--slippage", "0.5", "--timeout", "300"])
+            log(f"   tx={(r.get('tx') or {}).get('status')} out={(r.get('swap') or {}).get('output')}")
+            break
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--wallet", required=True)
+    ap.add_argument("--dest", default="ethereum")
+    ap.add_argument("--min-value", type=float, default=1.0)
+    ap.add_argument("--stages", default="ABCD")
+    ap.add_argument("--plan-only", action="store_true")
+    a = ap.parse_args()
+
+    wl = run(["zerion", "wallet", "list"])
+    addr = next((w["evmAddress"] for w in wl.get("wallets", []) if w["name"] == a.wallet), None)
+    if not addr:
+        log(f"wallet '{a.wallet}' not in vault"); return 1
+
+    chains = chains_with_value(addr, a.min_value, a.dest)
+    log(f"wallet {a.wallet} = {addr}")
+    log(f"{len(chains)} trade-capable chains with value >= ${a.min_value:g}")
+    if a.plan_only:
+        for c, ps in sorted(chains.items(), key=lambda kv: -sum(x['value'] for x in kv[1])):
+            nat = sum(x["value"] for x in ps if x["native"])
+            log(f"   {sum(x['value'] for x in ps):10,.2f} {c:22s} -> {target_for(c)}"
+                f"   native ${nat:,.2f}")
+        return 0
+
+    if "A" in a.stages:
+        stage_a(a.wallet, chains, a.dest, a.min_value)
+    if "B" in a.stages:
+        stage_b(a.wallet, addr, a.dest, a.min_value)
+    if "C" in a.stages:
+        stage_c(a.wallet, addr, a.dest, a.min_value)
+    if "D" in a.stages:
+        stage_d(a.wallet, a.dest, a.min_value)
+    log("\nLIQUIDATEDONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/treasury-liquidation/scripts/liquidate.py
+++ b/skills/treasury-liquidation/scripts/liquidate.py
@@ -100,9 +100,13 @@ def stage_a(wallet, chains, dest, min_value):
         native_usd = (nat or {}).get("value") or 0.0
         budget = affordable_swaps(ch, native_usd)
         if budget < 1:
+            # The figure comes from the positions indexer, which lags a fresh
+            # top-up by minutes: a bridge can deliver native on-chain while this
+            # still reads $0.00. Before trusting a zero, check eth_getBalance.
             log(f"{ch}: SKIPPED -- gas ${native_usd:,.2f} cannot fund a sweep plus "
                 f"the bridge that must follow (needs > ${bridge_gas_usd(ch):.2f}). "
-                f"Top up native on {ch} to recover this chain.")
+                f"Top up native on {ch} to recover this chain (if you just did, "
+                f"the indexer may not have caught up -- verify via RPC and rerun).")
             continue
 
         plan = run(["zerion", "consolidate", ch, tgt, "--wallet", wallet,

--- a/skills/treasury-liquidation/scripts/netutil.py
+++ b/skills/treasury-liquidation/scripts/netutil.py
@@ -1,0 +1,45 @@
+"""HTTP helpers.
+
+Both api.zerion.io and public RPC endpoints reject Python's default urllib
+User-Agent with 403. Every request here sets a browser-ish UA. Without it you get
+a 403 that looks exactly like a bad API key.
+"""
+import base64, json, urllib.request
+
+UA = "Mozilla/5.0 (treasury-liquidation)"
+
+
+def get_json(url, api_key=None, timeout=60):
+    headers = {"accept": "application/json", "User-Agent": UA}
+    if api_key:
+        headers["Authorization"] = "Basic " + base64.b64encode(f"{api_key}:".encode()).decode()
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return json.loads(r.read())
+
+
+def head_status(url, api_key=None, timeout=15):
+    """Return an HTTP status code without raising, for liveness checks."""
+    headers = {"accept": "application/json", "User-Agent": UA}
+    if api_key:
+        headers["Authorization"] = "Basic " + base64.b64encode(f"{api_key}:".encode()).decode()
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status
+    except urllib.error.HTTPError as e:
+        return e.code
+    except Exception:
+        return None
+
+
+def rpc(url, method, params, timeout=20):
+    body = json.dumps({"jsonrpc": "2.0", "method": method, "params": params, "id": 1}).encode()
+    req = urllib.request.Request(
+        url, data=body,
+        headers={"Content-Type": "application/json", "User-Agent": UA})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        d = json.loads(r.read())
+    if "error" in d:
+        raise RuntimeError(d["error"])
+    return d["result"]

--- a/skills/treasury-liquidation/scripts/preflight.py
+++ b/skills/treasury-liquidation/scripts/preflight.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Verify auth before any liquidation run. Fails fast with actionable fixes.
+
+An invalid/revoked ZERION_API_KEY makes every CLI command HANG FOREVER with no
+error, so this checks the key over raw HTTP (fast, unambiguous) before trusting
+the CLI at all.
+
+Usage:
+    preflight.py --wallet "<wallet-name>"
+    preflight.py --wallet "<wallet-name>" --key zk_...
+"""
+import argparse, json, os, subprocess, sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from netutil import head_status  # noqa: E402
+
+API = "https://api.zerion.io/v1"
+
+
+def resolve_key(explicit=None):
+    """Key precedence mirrors the CLI: env wins over config.json."""
+    sources = []
+    if explicit:
+        sources.append(("--key", explicit))
+    env = os.environ.get("ZERION_API_KEY")
+    if env:
+        sources.append(("env ZERION_API_KEY", env))
+    cfg_path = os.path.expanduser("~/.zerion/config.json")
+    cfg = {}
+    if os.path.exists(cfg_path):
+        try:
+            cfg = json.load(open(cfg_path))
+        except Exception:
+            pass
+    if cfg.get("apiKey"):
+        sources.append(("config.json", cfg["apiKey"]))
+    return sources, cfg
+
+
+def check_key(key, timeout=15):
+    """Return (ok, detail). Raw HTTP so a bad key errors instead of hanging."""
+    code = head_status(f"{API}/chains", api_key=key, timeout=timeout)
+    return code == 200, f"HTTP {code}" if code else "no response"
+
+
+def cli(args, key, timeout=60):
+    env = dict(os.environ, ZERION_API_KEY=key)
+    try:
+        p = subprocess.run(args, capture_output=True, text=True, timeout=timeout, env=env)
+        out = p.stdout + p.stderr
+        i = out.find("{")
+        return json.JSONDecoder().raw_decode(out[i:])[0] if i >= 0 else None
+    except subprocess.TimeoutExpired:
+        return {"error": {"code": "cli_hang"}}
+    except Exception:
+        return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--wallet", required=True)
+    ap.add_argument("--key")
+    a = ap.parse_args()
+
+    sources, _ = resolve_key(a.key)
+    if not sources:
+        print("FAIL: no API key found (--key, $ZERION_API_KEY, or ~/.zerion/config.json)")
+        return 1
+
+    print("API key sources, in the CLI's precedence order:")
+    good = None
+    for name, k in sources:
+        ok, detail = check_key(k)
+        print(f"  {'OK  ' if ok else 'BAD '} {name:22s} {k[:11]}...{k[-4:]}  {detail}")
+        if ok and good is None:
+            good = k
+
+    winner = sources[0]
+    if not check_key(winner[1])[0]:
+        print(f"\nFAIL: the winning source ({winner[0]}) holds an INVALID key.")
+        print("  The CLI will HANG SILENTLY on every command, including reads.")
+        if good:
+            print(f"  A valid key exists in another source. Prefix commands:")
+            print(f"    ZERION_API_KEY={good} zerion ...")
+            print("  Shell env does not persist between agent tool calls -- prefix EVERY call.")
+        else:
+            print("  No valid key in any source. Get one at dashboard.zerion.io.")
+        return 1
+    key = winner[1]
+    print(f"\nUsing {winner[0]}.")
+
+    # Wallet must exist locally (keys required to sign).
+    wl = cli(["zerion", "wallet", "list"], key)
+    if not wl:
+        print("FAIL: `zerion wallet list` returned nothing.")
+        return 1
+    names = {w["name"]: w for w in wl.get("wallets", [])}
+    if a.wallet not in names:
+        print(f"FAIL: wallet '{a.wallet}' not in local vault. Available: {sorted(names)}")
+        print("  Without the private key nothing can be signed. Import it first.")
+        return 1
+    print(f"Wallet '{a.wallet}' = {names[a.wallet]['evmAddress']}")
+
+    # An expired policy blocks every write with `policy denied`, before broadcast.
+    toks = cli(["zerion", "agent", "list-tokens"], key) or {}
+    active = [t for t in toks.get("tokens", [])
+              if t.get("wallet") == a.wallet and t.get("active")]
+    if not active:
+        print(f"\nFAIL: no ACTIVE agent token for '{a.wallet}'. Writes will fail.")
+        print_token_fix(a.wallet)
+        return 1
+
+    pols = cli(["zerion", "agent", "list-policies"], key) or {}
+    exp = {p["name"]: r["timestamp"]
+           for p in pols.get("policies", [])
+           for r in p.get("rules", []) if r["type"] == "expires_at"}
+    import datetime as dt
+    now = dt.datetime.now(dt.timezone.utc)
+    live = False
+    for t in active:
+        for p in t.get("policies", []):
+            ts = exp.get(p["name"])
+            if not ts:
+                continue
+            when = dt.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            left = when - now
+            state = "EXPIRED" if left.total_seconds() <= 0 else f"{left.days}d {left.seconds//3600}h left"
+            print(f"  token {t['name']} -> policy {p['name']}: {state}")
+            if left.total_seconds() > 0:
+                live = True
+    if not live:
+        print(f"\nFAIL: every policy on '{a.wallet}' has expired.")
+        print_token_fix(a.wallet)
+        return 1
+
+    print("\nPreflight OK. Writes should succeed.")
+    return 0
+
+
+def print_token_fix(wallet):
+    print("  Fix (create-policy is agent-runnable; create-token is NOT):")
+    print("    zerion agent create-policy --name liq-3d --expires 3d")
+    print(f'    zerion agent create-token --name liq --wallet "{wallet}" --policy <policy-id>')
+    print("  create-token needs a REAL TTY. The agent cannot run it, and neither can")
+    print("  Claude Code's `!` prefix -- both fail 'Passphrase must be entered in an")
+    print("  interactive terminal'. The user must run it in their own terminal window.")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/treasury-liquidation/scripts/verify.py
+++ b/skills/treasury-liquidation/scripts/verify.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""On-chain truth. Never report money as moved based on CLI output alone.
+
+A hung `zerion swap` is indistinguishable from a pending one: the process stays
+alive and prints nothing. Equal `latest` and `pending` nonces prove nothing was
+ever broadcast.
+
+Usage:
+    verify.py --address 0x...                        # ETH + USDC on Ethereum, nonces
+    verify.py --address 0x... --token 0xa0b8...      # any ERC-20
+    verify.py --address 0x... --rpc https://...      # non-Ethereum chain
+"""
+import argparse, os, sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from netutil import rpc  # noqa: E402
+
+# llamarpc 521s and cloudflare-eth returns internal errors; publicnode is reliable.
+DEFAULT_RPC = "https://ethereum-rpc.publicnode.com"
+USDC_ETHEREUM = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+
+
+
+
+def erc20_balance(url, token, addr, decimals=6):
+    data = "0x70a08231" + addr.lower().replace("0x", "").rjust(64, "0")
+    return int(rpc(url, "eth_call", [{"to": token, "data": data}, "latest"]), 16) / 10 ** decimals
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--address", required=True)
+    ap.add_argument("--rpc", default=DEFAULT_RPC)
+    ap.add_argument("--token", help="ERC-20 contract (default: USDC on Ethereum)")
+    ap.add_argument("--decimals", type=int, default=6)
+    a = ap.parse_args()
+
+    native = int(rpc(a.rpc, "eth_getBalance", [a.address, "latest"]), 16) / 1e18
+    print(f"native:  {native:.9f}")
+
+    tok = a.token or USDC_ETHEREUM
+    try:
+        print(f"token:   {erc20_balance(a.rpc, tok, a.address, a.decimals):,.6f}  ({tok[:10]}...)")
+    except Exception as e:
+        print(f"token:   ERROR {e}")
+
+    latest = int(rpc(a.rpc, "eth_getTransactionCount", [a.address, "latest"]), 16)
+    pending = int(rpc(a.rpc, "eth_getTransactionCount", [a.address, "pending"]), 16)
+    print(f"nonce:   latest={latest} pending={pending}"
+          + ("  (equal -> nothing in flight)" if latest == pending
+             else f"  ({pending - latest} tx in mempool)"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a two-phase multi-chain treasury skill:

1. **Drain** — send every token above a floor from wallet A to wallet B across all chains as raw transfers, so asset identity and cost basis survive and the sale can happen later in B.
2. **Liquidate** — convert a wallet's whole multi-chain portfolio into USDC on one destination chain, keeping a gas reserve everywhere.

They compose (drain A→B, then liquidate B) or run independently.

## Why this isn't just a copy of a working script

Two structural gas bugs showed up across real multi-chain runs. Both are fixed here rather than shipped:

### Stage A now reserves gas for the stage-B bridge that follows it

Every swap spends the chain's native token, and stage B then needs one more transaction to bridge the proceeds out. Sweeping a chain until its gas runs out converts sellable tokens into an **unsendable** pile of USDC/WETH — strictly worse than not sweeping, because the original assets are gone too. The bridge fails `not_enough_base_asset_balance` and the value sits there.

`gas.affordable_swaps()` caps each chain's sweep at what it can fund while still paying for the bridge, defers surplus rows lowest-value-first (with a log line, never silently), and skips chains that cannot fund even one bridge — with a top-up hint instead of a confusing downstream failure.

Observed twice:
- 44 swaps on `robinhood` spent \$12 of ETH (~\$0.27 each) and left **\$1,893 of WETH** unbridgeable
- a `polygon` sweep attempted 3 swaps while holding \$0.00 of POL

### Gas reserves are now USD-aware

A native-unit reserve is worth cents on cheap chains — 1 POL ≈ \$0.20, 1 XDAI ≈ \$1.00, 1 S ≈ \$0.03. Combined with a flat "skip if balance < \$5" test, a chain passes the check, bridges nearly everything home, and is left holding a reserve too small to broadcast anything. Its residue is then stranded until someone tops it up by hand.

`reserve_for(chain, price)` keeps the larger of the per-chain native figure and `MIN_RESERVE_USD` (\$2.50). Stage C applies `MIN_BRIDGE_USD` to the amount **actually leaving** (balance minus reserve) rather than the pre-reserve balance. Stage D's native swap and `drain.py` take the same fix.

The cost of both guards is a few dollars of gas retained per chain. That's the intended trade: a chain with gas can be retried, a chain without gas cannot.

## Calibration note

`DEFAULT_SWAP_GAS_USD` is rounded **up** from the observed ~\$0.27/swap. An earlier \$0.12 estimate would have permitted 96 swaps on the \$12 robinhood balance and reproduced the exact failure the cap exists to prevent — so the constant is deliberately conservative. Overestimating leaves a little dust; underestimating strands a whole chain's proceeds.

## Contents

| file | role |
|---|---|
| `SKILL.md` | workflow, staging rationale, what the CLI cannot do |
| `references/gotchas.md` | failure modes that are silent, expensive, and not inferable from CLI output |
| `scripts/preflight.py` | auth check — an invalid API key makes every command hang forever with no error |
| `scripts/inventory.py` | wallet vs DeFi positions, unreachable chains, broken price feeds |
| `scripts/drain.py` | phase 1 — raw sends A→B |
| `scripts/liquidate.py` | phase 2 — 4-stage sweep + bridge → USDC |
| `scripts/verify.py` | on-chain truth via RPC, never CLI output |
| `scripts/gas.py` | per-chain reserves and gas affordability |

## Testing

- All scripts compile (`python3 -m py_compile`)
- `affordable_swaps()` regression-checked against both real failures: robinhood \$12 → caps at 38 swaps (below the 44 that broke it); polygon \$0.00 → 0, chain skipped up front
- Reserve math verified across cheap-gas and ETH-denominated chains

Scripts are stdlib-only (no new dependencies) and contain no addresses or credentials beyond the public USDC mainnet contract in `verify.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)